### PR TITLE
#14 setup process unicode

### DIFF
--- a/src/scribe_data/extract_transform/process_unicode.py
+++ b/src/scribe_data/extract_transform/process_unicode.py
@@ -1,0 +1,47 @@
+"""
+Process Unicode
+------------
+
+Module for processing Unicode based corpuses for autosuggestion generation.
+
+Contents:
+    gen_emoji_autosuggestions
+"""
+
+def gen_emoji_autosuggestions(
+    language="English",
+    num_emojis=500,
+    ignore_keywords=None,
+    update_scribe_apps=False,
+    verbose=True,
+):
+    """
+    Generates a dictionary of keywords (keys) and emoji unicodes(s) associated with them (values).
+
+    Parameters
+    ----------
+        language : string (default=en)
+            The language autosuggestions are being generated for.
+
+        num_emojis: int (default=500)
+            The number of emojis that autosuggestions should be generated from.
+
+        ignore_keywords : str or list (default=None)
+            Keywords that should be ignored.
+
+        update_scribe_apps : bool (default=False)
+            Saves the created dictionaries as JSONs in Scribe app directories.
+
+        verbose : bool (default=True)
+            Whether to show a tqdm progress bar for the process.
+
+    Returns
+    -------
+        Autosuggestions dictionaries for emoji keywords-to-unicode are saved locally or uploaded to Scribe apps.
+    """
+
+    autosuggest_dict = {}
+
+    # TODO
+
+    return autosuggest_dict


### PR DESCRIPTION
Hey @andrewtavis!

Added some quick setup for the emoji work.

**Some notes:**
- While it should be possible to get the _'emoji-to-keyword'_ relationships from Unicode, i.e.
```json
      "😀": {
        "default": [
          "face",
          "grin",
          "grinning face"
        ],
        "tts": [
          "grinning face"
        ]
      },
```
(example from [here](https://github.com/unicode-org/cldr-json/blob/f27f55f1dd487af7cf4260f56296ee1c7649b7fc/cldr-json/cldr-annotations-full/annotations/en/annotations.json#L3283-L3292)),

I'm potentially thinking that the inverse, _'keyword-to-emoji',_ would be useful, i.e. resulting in something of the like:  
```
# below not json, only for illustration
{
  face: [😀, ...],
  grin: [😀, ...],
  grinning: [😀, ...],
}
```
This might be useful perhaps, since the trigger for the autosuggestion would be the keyword, not the emoji. References off of the keyword could be more important. 
- Also, I'm thinking that storing the Unicode Code Point for the emoji, as opposed to one of its rendered image varieties, might also make more sense. For the emoji in the above point, I believe it would be `U+1F600`. This is more to perhaps facilitate the use of the emoji data independent of the platform or OS - Android and iOS use different images for emojis, but the Unicode code is the same. The code could be provided and the platform renders the emoji as it would.
- Haven't added anything `pyicu` yet, as still looking into if it could be easily used for this work.

Let me know any thoughts on the above points :rocket: 
