### PR TITLE
#14 download and load cldr data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ dist
 *.egg-info
 # Caches
 __pycache__
+
+# NPM files
+###########
+node_modules
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "cldr-annotations-derived-full": "latest"
+  }
+}

--- a/src/scribe_data/extract_transform/process_unicode.py
+++ b/src/scribe_data/extract_transform/process_unicode.py
@@ -8,6 +8,10 @@ Contents:
     gen_emoji_autosuggestions
 """
 
+import json
+
+from scribe_data.load.update_utils import get_language_iso
+
 def gen_emoji_autosuggestions(
     language="English",
     num_emojis=500,
@@ -42,6 +46,19 @@ def gen_emoji_autosuggestions(
 
     autosuggest_dict = {}
 
-    # TODO
+    ### TODO further updates - here for data loading illustration
+
+    language = get_language_iso(language)
+
+    cldr_file_path = f'node_modules/cldr-annotations-derived-full/annotationsDerived/{language}/annotations.json'
+
+    with open(cldr_file_path, 'r') as file:
+        cldr_data = json.load(file)
+
+    emoji_dict = cldr_data['annotationsDerived']['annotations']
+
+    print("Number of emojis loaded:", len(emoji_dict))
+
+    ###
 
     return autosuggest_dict

--- a/src/scribe_data/extract_transform/process_wiki.py
+++ b/src/scribe_data/extract_transform/process_wiki.py
@@ -334,7 +334,7 @@ def gen_autosuggestions(
         ignore_words : str or list (default=None)
             Strings that should be removed from the text body.
 
-        update_scribe : bool (default=False)
+        update_scribe_apps : bool (default=False)
             Saves the created dictionaries as JSONs in Scribe app directories.
 
         verbose : bool (default=True)

--- a/src/scribe_data/load/gen_emoji_suggestions.ipynb
+++ b/src/scribe_data/load/gen_emoji_suggestions.ipynb
@@ -71,6 +71,26 @@
     "pwd = pwd.split(\"scribe_data\")[0]\n",
     "sys.path.append(pwd)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2add942e",
+   "metadata": {},
+   "source": [
+    "# Download Latest Unicode"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e166da1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    ". $HOME/.nvm/nvm.sh # Pick up the 'npm' command\n",
+    "npm install"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
**Description:**

- Added dependency to the [`cldr-annotations-derived-full`](https://www.npmjs.org/package/cldr-annotations-derived-full) npm package for the emoji data
- Added step to the Jupyter Notebook to download the latest CLDR data
- Added quick initial code just to illustrate the ability to load CLDR data (further updates/changes incoming)
- Fixed minor in-source doc for `gen_autosuggestions()`

**Some notes:**
- I noticed that Unicode actually appears to keep the cldr-json data as separate [npm packages](https://github.com/unicode-org/cldr-json/blob/main/PACKAGES.md) :raised_hands:, which is awesome 
  - Separate packages seems convenient so Scribe is able to only get the data that it needs
  - Using `npm`, Scribe could also easily simply reference whatever the tagged `latest` version of the package is. Getting newest data is a matter of `npm install`
  - `cldr-annotations-derived-full` appeared to be the package Scribe would need for the emoji work, but can look into if other packages make sense instead, e.g. one of the other `cldr-annotations-*` packages
  - Can also add multiple packages if needed (in the `package.json` file); `npm install` would get the latest for all
- Had to wrestle a bit with how to pick up the `npm` command inside Jupyter, but running the `nvm` shell setup seems to do the trick:
  - `. $HOME/.nvm/nvm.sh` (btw if [`nvm`](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm#using-a-node-version-manager-to-install-nodejs-and-npm) is used for `node` and `npm` version management, this is often what is run anyways whenever a new shell is opened)
  - Without the above, Jupyter does not have `npm` in the `$PATH` due to how the shell process works in Jupyter
  - Been a while since I've used Jupyter; so if there's a better way to pick up binaries/commands from inside Jupyter, let me know :raised_hands: 

Quick PR to at least get and load the CLDR data. Processing logic incoming. Let me know any thoughts :v: 