### PR TITLE
Add English verbs query file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Scribe-Data tries to follow [semantic versioning](https://semver.org/), a MAJOR.
 
 Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
 
+# [Upcoming] Scribe-Data 3.2.0
+
+### ✨ Features
+
+- The data and process needed for an English keyboard has been added.
+  - The Wikidata queries for English have been updated to get all nouns and verbs.
+  <!-- - Formatting scripts have been written to prepare the queried data and load it into an SQLite database.
+  - English has been added to the data ETL process. -->
+- The data update process has been cleaned up in preparation for future changes to Scribe-Data and to implement better practices.
+
 # Scribe-Data 3.1.0
 
 ### ✨ Features

--- a/src/scribe_data/extract_transform/English/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/English/verbs/query_verbs.sparql
@@ -1,28 +1,53 @@
 # All English (Q1860) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?verb ?simplePast ?pastParticiple WHERE {
+SELECT DISTINCT ?infinitive ?presFPS ?presTPS ?simpPast ?pastPart WHERE {
+  # Infinitive (required)
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q1860 ;
     wikibase:lexicalCategory wd:Q24905 ;
-    wikibase:lemma ?lemma .
+    wikibase:lemma ?infinitive .
+
+  # Simple Present
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?presFPSForm .
+    ?presFPSForm ontolex:representation ?presFPS ;
+      wikibase:grammaticalFeature wd:Q3910936 ;
+      FILTER NOT EXISTS { ?presFPSForm wikibase:grammaticalFeature wd:Q51929074 . }
+      FILTER NOT EXISTS { ?presFPSForm wdt:P6191 wd:Q181970 . }
+      FILTER NOT EXISTS { ?presFPSForm wikibase:grammaticalFeature wd:Q126473 . }
+  } .
+
+  # Third-person Singular
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?presTPSForm .
+    ?presTPSForm ontolex:representation ?presTPS ;
+    wikibase:grammaticalFeature wd:Q51929074 ;
+    wikibase:grammaticalFeature wd:Q110786 ;
+    wikibase:grammaticalFeature wd:Q3910936 ;
+    FILTER NOT EXISTS { ?presFPSForm wdt:P6191 wd:Q181970 . }
+    FILTER NOT EXISTS { ?presFPSForm wikibase:grammaticalFeature wd:Q126473 . }
+  } .
 
   # Simple Past
   OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?simplePastForm .
-    ?simplePastForm ontolex:representation ?simplePast ;
-      wikibase:grammaticalFeature wd:Q1392475 ;
+    ?lexeme ontolex:lexicalForm ?simpPastForm .
+    ?simpPastForm ontolex:representation ?simpPast ;
+    wikibase:grammaticalFeature wd:Q1392475 ;
+    FILTER NOT EXISTS { ?presFPSForm wdt:P6191 wd:Q181970 . }
+    FILTER NOT EXISTS { ?presFPSForm wikibase:grammaticalFeature wd:Q126473 . }
   } .
 
   # Past Participle
   OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?pastParticipleForm .
-    ?pastParticipleForm ontolex:representation ?pastParticiple ;
-      wikibase:grammaticalFeature wd:Q1230649 ;
+    ?lexeme ontolex:lexicalForm ?pastPartForm .
+    ?pastPartForm ontolex:representation ?pastPart ;
+    wikibase:grammaticalFeature wd:Q1230649 ;
+    FILTER NOT EXISTS { ?presFPSForm wdt:P6191 wd:Q181970 . }
+    FILTER NOT EXISTS { ?presFPSForm wikibase:grammaticalFeature wd:Q126473 . }
   } .
 
   SERVICE wikibase:label {
     bd:serviceParam wikibase:language "[AUTO_LANGUAGE]".
-    ?lemma rdfs:label ?verb .
   }
 }


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀

If you're not already a member of our public Matrix community, please consider joining via the following link:
https://matrix.to/#/#scribe_community:matrix.org

It'd be great to have you!

Also if you're new to open source, check that the email you use for GitHub (https://github.com/settings/emails) is the same the one you have for git so you get credit for your contribution. You can see your git email by typing `git config user.email` and set it globally with `git config --global user.email "your_email@email.com"`.
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [ ] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have updated the [CHANGELOG](https://github.com/scribe-org/Scribe-Data/blob/main/CHANGELOG.md) with a description of my changes for the upcoming release (if necessary) <!-- ... or I'll send a commit with this now 🙃 -->

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

This PR includes the query for all English verbs. There are a few points here:
- The English verbs model is quite lean as the goal was to not have "unneeded data"
  - We thus don't have forms for all conjugations, but only those that are different
  - In the formatting process we still need to map them to all of them to make sure that the app references don't need to be rewritten for this case
- "To be" needs to get hard coded within the verbs formatting process as the data structure is dramatically different and adding in all of the conditional selections was getting really annoying
  - Let's discuss if we need to check other irregular verbs
- Checked by talking about this a bit at CCCamp with one of the main Wikidata Lexeme devs/community members 😊

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- No directly related issue 🙃 Tangentially related to #39