### PR TITLE
refactor(utils.py): move language data to JSON file (resolves #52)

### DIFF
--- a/src/scribe_data/resources/language_meta_data.json
+++ b/src/scribe_data/resources/language_meta_data.json
@@ -1,0 +1,128 @@
+{
+    "used by": "Scribe-Data/src/scribe_data/utils.py",
+    "description": {
+        "entry": {
+            "language": "the supported language. All lowercase",
+            "iso": "the ISO 639 code for 'language'. See https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes . All lowercase",
+            "qid": "the unique identifier of 'language' on Wikidata. 'Q' followed by one or more digits. See https://www.wikidata.org/wiki/Q43649390",
+            "remove-words": "words that should not be included as autosuggestions for the given language.",
+            "ignore-words": "TODO. Case sensitive."
+        }
+    },
+    "languages": [
+        {
+            "language": "english",
+            "iso": "en",
+            "qid": "Q1860",
+            "remove-words": [
+                "of",
+                "the",
+                "The",
+                "and"
+            ],
+            "ignore-words": []
+        },
+        {
+            "language": "french",
+            "iso": "fr",
+            "qid": "Q150",
+            "remove-words": [
+                "of",
+                "the",
+                "The",
+                "and"
+            ],
+            "ignore-words": [
+                "XXe"
+            ]
+        },
+        {
+            "language": "german",
+            "iso": "de",
+            "qid": "Q188",
+            "remove-words": [
+                "of",
+                "the",
+                "The",
+                "and",
+                "NeinJa",
+                "et",
+                "redirect"
+            ],
+            "ignore-words": [
+                "Gemeinde",
+                "Familienname"
+            ]
+        },
+        {
+            "language": "italian",
+            "iso": "it",
+            "qid": "Q652",
+            "remove-words": [
+                "of",
+                "the",
+                "The",
+                "and",
+                "text",
+                "from"
+            ],
+            "ignore-words": [
+                "The",
+                "ATP"
+            ]
+        },
+        {
+            "language": "portuguese",
+            "iso": "pt",
+            "qid": "Q5146",
+            "remove-words": [
+                "of",
+                "the",
+                "The",
+                "and",
+                "jbutadptflora"
+            ],
+            "ignore-words": []
+        },
+        {
+            "language": "russian",
+            "iso": "ru",
+            "qid": "Q7737",
+            "remove-words": [
+                "of",
+                "the",
+                "The",
+                "and"
+            ],
+            "ignore-words": []
+        },
+        {
+            "language": "spanish",
+            "iso": "es",
+            "qid": "Q1321",
+            "remove-words": [
+                "of",
+                "the",
+                "The",
+                "and"
+            ],
+            "ignore-words": []
+        },
+        {
+            "language": "swedish",
+            "iso": "sv",
+            "qid": "Q9027",
+            "remove-words": [
+                "of",
+                "the",
+                "The",
+                "and",
+                "Checklist",
+                "Catalogue"
+            ],
+            "ignore-words": [
+                "databasdump"
+            ]
+        }
+    ]
+}

--- a/tests/load/test_update_utils.py
+++ b/tests/load/test_update_utils.py
@@ -196,7 +196,6 @@ def test_get_path_from_load_dir():
 
 
 def test_get_path_from_et_dir():
-    # TODO: file path is same as above. Is this correct?
     assert utils.get_path_from_et_dir() == "../../../.."
 
 


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
Moves language meta data from python source code into an external JSON resource which is loaded when the `utils` module is imported.

### Notes
#### `language-meta-data.json`
Please place attention to the comment properties: "description", "iso", "qid" & "remove-words".

#### `utils.py`
Couldn't think of a better name for the `_find` function - suggestions welcome.

 

- #52
