### PR TITLE
fixes #55 : Refactor ISO code usage using Python langcodes

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,3 +21,5 @@ dependencies:
       - regex>=2023.8.8
       - SPARQLWrapper>=2.0.0
       - tensorflow>=2.11.0
+      - langcodes>=3.0.0
+      - language_data>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ tabulate>=0.8.9
 tensorflow>=2.5.1
 tqdm==4.56.1
 transformers>=4.12
+langcodes>=3.0.0
+language_data>=1.0.0

--- a/src/scribe_data/utils.py
+++ b/src/scribe_data/utils.py
@@ -158,11 +158,9 @@ def get_language_iso(language: str) -> str:
     """
     try:
         iso_code = str(langcodes.find(language).language)
-        return iso_code
-    except langcodes.LanguageTagError:
+    except LookupError:
         raise ValueError(f"{language.capitalize()} is currently not a supported language for ISO conversion.")
-
-
+    return iso_code
 
 def get_language_from_iso(iso: str) -> str:
     """
@@ -178,11 +176,12 @@ def get_language_from_iso(iso: str) -> str:
         str
             The name for the language which has an ISO value of iso.
     """
-    try:
-        language_name = str(Language.make(language=iso).display_name())
-        return language_name
-    except langcodes.LanguageTagError:
-        raise ValueError(f"{iso} is currently not a supported ISO language.")
+
+    language_name = str(Language.make(language=iso).display_name())
+    if "Unknown language" in str(language_name):
+        raise ValueError(f"{iso.upper()} is currently not a supported ISO language.")
+    return language_name
+
 
 def get_language_words_to_remove(language: str) -> list[str]:
     """

--- a/src/scribe_data/utils.py
+++ b/src/scribe_data/utils.py
@@ -27,6 +27,8 @@ import sys
 from importlib import resources
 from pathlib import Path
 from typing import Any
+import langcodes
+from langcodes import *
 
 PROJECT_ROOT = "Scribe-Data"
 
@@ -154,12 +156,12 @@ def get_language_iso(language: str) -> str:
         str
             The ISO code for the language.
     """
-    return _find(
-        "language",
-        language,
-        "iso",
-        f"{language.capitalize()} is currently not a supported language for ISO conversion.",
-    )
+    try:
+        iso_code = str(langcodes.find(language).language)
+        return iso_code
+    except langcodes.LanguageTagError:
+        raise ValueError(f"{language.capitalize()} is currently not a supported language for ISO conversion.")
+
 
 
 def get_language_from_iso(iso: str) -> str:
@@ -176,13 +178,11 @@ def get_language_from_iso(iso: str) -> str:
         str
             The name for the language which has an ISO value of iso.
     """
-    return _find(
-        "iso",
-        iso,
-        "language",
-        f"{iso.upper()} is currently not a supported ISO language.",
-    ).capitalize()
-
+    try:
+        language_name = str(Language.make(language=iso).display_name())
+        return language_name
+    except langcodes.LanguageTagError:
+        raise ValueError(f"{iso} is currently not a supported ISO language.")
 
 def get_language_words_to_remove(language: str) -> list[str]:
     """

--- a/tests/load/test_update_utils.py
+++ b/tests/load/test_update_utils.py
@@ -1,6 +1,9 @@
 import unittest
 import pytest
 
+import sys
+sys.path.append('../../src')
+
 from scribe_data import utils
 
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

- Refactor ISO Code Usage: Replaces the existing ISO code and language retrieval mechanism in Scribe with the langcodes library for improved language code handling. Refer to the functions ```get_language_iso``` and ```get_language_from_iso``` in ```src/scribe_data/utlis.py```.
- Incorporate ```langcodes``` and ```language_data```: Adds langcodes and language_data as dependencies to ```environment.yaml``` file.
- Uses ```LanguageTagError``` attribute of ```langcodes``` with try and except for error handling.
- Tested these functions manually using the tests given in ```test_update_utils.py``` file.

### Related issue
- #55 
