### PR TITLE
fix: update the upstream repo url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ git clone https://github.com/<your-username>/Scribe-Data.git
 # Navigate to the newly cloned directory.
 cd Scribe-Data
 # Assign the original repo to a remote called "upstream".
-git remote add upstream https://github.com/scribe-org/Scibe-Data.git
+git remote add upstream https://github.com/scribe-org/Scribe-Data.git
 ```
 
 - Now, if you run `git remote -v` you should see two remote repositories named:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ git clone https://github.com/<your-username>/Scribe-Data.git
 # Navigate to the newly cloned directory.
 cd Scribe-Data
 # Assign the original repo to a remote called "upstream".
-git remote add upstream https://github.com/scribe-org/Scibe-Data.git
+git remote add upstream https://github.com/scribe-org/Scribe-Data.git
 ```
 
 - Now, if you run `git remote -v` you should see two remote repositories named:


### PR DESCRIPTION

### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch


### Description

The issue is to update the upstream repo URL in the [development environment guide](https://scribe-data.readthedocs.io/en/latest/notes.html#dev-env)


### Related issue
This is linked to #85 

