### PR TITLE
Add translation funcs to utils

### DIFF
--- a/src/scribe_data/utils.py
+++ b/src/scribe_data/utils.py
@@ -435,13 +435,37 @@ def check_and_return_command_line_args(
 
 
 def translation_interrupt_handler(source_language, translations):
+    """
+    Handles interrupt signals and saves the current translation progress.
+
+    Parameters
+    ----------
+        source_language : str
+            The source language being translated from.
+
+        translations : list[dict]
+            The current list of translations.
+    """
     print("\nThe interrupt signal has been caught and the current progress is being saved...")
     with open(f"{get_language_dir_path(source_language)}/formatted_data/translated_words.json", 'w', encoding='utf-8') as file:
         json.dump(translations, file, ensure_ascii=False, indent=4)
     print("The current progress is saved to the translated_words.json file.")
     exit()
 
-def get_target_languages(source_lang)->list[str]:
+def get_target_langcodes(source_lang)->list[str]:
+    """
+    Returns a list of target language ISO codes for translation.
+
+    Parameters
+    ----------
+        source_lang : str
+            The source language being translated from.
+
+    Returns
+    -------
+        list[str]
+            A list of target language ISO codes.
+    """
     target_langcodes=[]
     for lang in get_scribe_languages():
         if lang!=source_lang:
@@ -451,12 +475,26 @@ def get_target_languages(source_lang)->list[str]:
     return target_langcodes
 
 def translate_to_other_languages(source_language, word_list, translations):
+    """
+    Translates a list of words from the source language to other target languages.
+
+    Parameters
+    ----------
+        source_language : str
+            The source language being translated from.
+
+        word_list : list[str]
+            The list of words to translate.
+
+        translations : list[dict]
+            The current list of translations.
+    """
     model = M2M100ForConditionalGeneration.from_pretrained("facebook/m2m100_418M")
     tokenizer = M2M100Tokenizer.from_pretrained("facebook/m2m100_418M")
 
     for word in word_list[len(translations):]:
         word_translations = {word: {}}
-        for lang_code in get_target_languages(source_language):
+        for lang_code in get_target_langcodes(source_language):
             tokenizer.src_lang = get_language_iso(source_language)
             encoded_word = tokenizer(word, return_tensors="pt")
             generated_tokens = model.generate(**encoded_word, forced_bos_token_id=tokenizer.get_lang_id(lang_code))

--- a/src/scribe_data/utils.py
+++ b/src/scribe_data/utils.py
@@ -10,6 +10,7 @@ Contents:
     get_language_from_iso,
     get_language_words_to_remove,
     get_language_words_to_ignore,
+    get_language_dir_path,
     get_path_from_format_file,
     get_path_from_load_dir,
     get_path_from_et_dir,
@@ -17,11 +18,15 @@ Contents:
     get_android_data_path,
     get_desktop_data_path,
     check_command_line_args,
-    check_and_return_command_line_args
+    check_and_return_command_line_args,
+    translation_interrupt_handler,
+    get_target_languages,
+    translate_to_other_languages
 """
 
 import ast
 import json
+import os
 import sys
 from importlib import resources
 from pathlib import Path
@@ -29,6 +34,8 @@ from typing import Any
 
 import langcodes
 from langcodes import Language
+
+from transformers import M2M100ForConditionalGeneration, M2M100Tokenizer
 
 PROJECT_ROOT = "Scribe-Data"
 
@@ -238,6 +245,11 @@ def get_language_words_to_ignore(language: str) -> list[str]:
         "ignore-words",
         f"{language.capitalize()} is currently not a supported language.",
     )
+
+
+def get_language_dir_path(language):
+    PATH_TO_SCRIBE_ORG = os.path.dirname(sys.path[0]).split("Scribe-Data")[0]
+    return f"{PATH_TO_SCRIBE_ORG}/Scribe-Data/src/scribe_data/extract_transform/languages/{language}"
 
 
 def get_path_from_format_file() -> str:

--- a/src/scribe_data/utils.py
+++ b/src/scribe_data/utils.py
@@ -248,6 +248,19 @@ def get_language_words_to_ignore(language: str) -> list[str]:
 
 
 def get_language_dir_path(language):
+    """
+    Returns the directory path for a specific language within the Scribe-Data project.
+
+    Parameters
+    ----------
+        language : str
+            The language for which the directory path is needed.
+
+    Returns
+    -------
+        str
+            The directory path for the specified language.
+    """
     PATH_TO_SCRIBE_ORG = os.path.dirname(sys.path[0]).split("Scribe-Data")[0]
     return f"{PATH_TO_SCRIBE_ORG}/Scribe-Data/src/scribe_data/extract_transform/languages/{language}"
 


### PR DESCRIPTION
### Contributor checklist

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

- Implemented `batch processing` for translation of words for a `batch_size` of 100, this way it is significantly faster to translate.
- Added four functions `get_language_dir_path` , `translation_interrupt_handler`, `get_target_langcodes` and `translate_to_other_languages`.
- Added doc strings.

### Related issue

- #72 , #73 , #74 , #75 , #76 , #77 , #78 , #79 
