### PR TITLE
Extract Lexeme IDs in SPARQL Queries for Language Totals

### DIFF
--- a/src/scribe_data/check_language_data.sparql
+++ b/src/scribe_data/check_language_data.sparql
@@ -1,7 +1,9 @@
 # This query is to check the totals of a given language on Wikidata.
 # Enter this query at https://query.wikidata.org/ and change the language where directed.
 
-SELECT ?wordCategory (COUNT(?wordCategory) as ?wordCategoryCounts) WHERE {
+SELECT 
+ (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+ ?wordCategory (COUNT(?wordCategory) as ?wordCategoryCounts) WHERE {
   # Enter language QID here.
   # You can find the QID of the language you want to check by searching for it on https://www.wikidata.org/.
   FILTER( ?language = wd:Q1860 )

--- a/src/scribe_data/check_language_data.sparql
+++ b/src/scribe_data/check_language_data.sparql
@@ -1,9 +1,7 @@
 # This query is to check the totals of a given language on Wikidata.
 # Enter this query at https://query.wikidata.org/ and change the language where directed.
 
-SELECT 
- (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
- ?wordCategory (COUNT(?wordCategory) as ?wordCategoryCounts) WHERE {
+SELECT ?wordCategory (COUNT(?wordCategory) as ?wordCategoryCounts) WHERE {
   # Enter language QID here.
   # You can find the QID of the language you want to check by searching for it on https://www.wikidata.org/.
   FILTER( ?language = wd:Q1860 )

--- a/src/scribe_data/extract_transform/languages/Arabic/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Arabic/nouns/query_nouns.sparql
@@ -3,8 +3,9 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?lexeme ?noun 
-WHERE {
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
+  ?noun WHERE {
+
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Arabic/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Arabic/nouns/query_nouns.sparql
@@ -1,8 +1,10 @@
 # All Arabic (Q13955) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?lexeme ?noun WHERE {
-
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  ?lexeme ?noun 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Arabic/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Arabic/nouns/query_nouns.sparql
@@ -1,10 +1,11 @@
 # All Arabic (Q13955) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?noun WHERE {
+  ?noun
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Arabic/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Arabic/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
   ?noun WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Arabic/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Arabic/verbs/query_verbs.sparql
@@ -1,9 +1,10 @@
 # All Arabic (Q13955) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?lexeme ?verb 
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
+  ?verb 
 WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q13955 ;

--- a/src/scribe_data/extract_transform/languages/Arabic/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Arabic/verbs/query_verbs.sparql
@@ -1,9 +1,10 @@
 # All Arabic (Q13955) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?verb 
+  ?verb
+
 WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q13955 ;

--- a/src/scribe_data/extract_transform/languages/Arabic/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Arabic/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
   ?verb 
 WHERE {
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Arabic/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Arabic/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All Arabic (Q13955) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?verb WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  ?lexeme ?verb 
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q13955 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Basque/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Basque/nouns/query_nouns.sparql
@@ -1,8 +1,9 @@
 # All Basque (Q8752) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
   ?noun 
 WHERE {
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Basque/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Basque/nouns/query_nouns.sparql
@@ -1,11 +1,11 @@
 # All Basque (Q8752) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT
+SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
   OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
-  ?noun 
-WHERE {
+  ?noun WHERE {
+
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Basque/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Basque/nouns/query_nouns.sparql
@@ -1,8 +1,10 @@
 # All Basque (Q8752) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?noun WHERE {
-
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  ?noun 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Basque/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Basque/nouns/query_nouns.sparql
@@ -1,10 +1,11 @@
 # All Basque (Q8752) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?noun WHERE {
+  ?noun
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Basque/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Basque/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
   ?noun WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Basque/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Basque/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All Basque (Q8752) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?verb WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  ?lexeme ?verb 
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q8752 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Basque/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Basque/verbs/query_verbs.sparql
@@ -1,9 +1,10 @@
 # All Basque (Q8752) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?verb 
+  ?verb
+
 WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q8752 ;

--- a/src/scribe_data/extract_transform/languages/Basque/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Basque/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
   ?verb 
 WHERE {
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Basque/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Basque/verbs/query_verbs.sparql
@@ -1,9 +1,10 @@
 # All Basque (Q8752) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?lexeme ?verb 
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
+  ?verb 
 WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q8752 ;

--- a/src/scribe_data/extract_transform/languages/Bengali/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Bengali/nouns/query_nouns.sparql
@@ -1,8 +1,10 @@
 # All Bengali (Q9610) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?lexeme ?noun WHERE {
-
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  ?noun 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Bengali/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Bengali/nouns/query_nouns.sparql
@@ -1,10 +1,11 @@
 # All Bengali (Q9610) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?noun WHERE {
+  ?noun
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Bengali/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Bengali/nouns/query_nouns.sparql
@@ -3,8 +3,9 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?noun 
-WHERE {
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
+  ?noun WHERE {
+
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Bengali/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Bengali/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
   ?noun WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Bengali/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Bengali/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All Bengali (Q9610) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?verb WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  ?verb 
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9610 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Bengali/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Bengali/verbs/query_verbs.sparql
@@ -1,10 +1,10 @@
 # All Bengali (Q9610) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?verb 
-WHERE {
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
+  ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9610 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Bengali/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Bengali/verbs/query_verbs.sparql
@@ -1,9 +1,11 @@
 # All Bengali (Q9610) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?verb WHERE {
+  ?verb
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9610 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Bengali/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Bengali/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
   ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9610 ;

--- a/src/scribe_data/extract_transform/languages/Bokmål/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Bokmål/nouns/query_nouns.sparql
@@ -4,6 +4,7 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
   ?singular ?plural ?gender 
 WHERE {
 

--- a/src/scribe_data/extract_transform/languages/Bokmål/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Bokmål/nouns/query_nouns.sparql
@@ -2,9 +2,12 @@
 # Enter this query at https://query.wikidata.org/.
 # Note that this query is for Bokmål (Q25167) rather than Nynorsk (Q25164).
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?singular ?plural ?gender 
+  ?singular
+  ?plural
+  ?gender
+
 WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Bokmål/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Bokmål/nouns/query_nouns.sparql
@@ -4,7 +4,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
   ?singular ?plural ?gender 
 WHERE {
 

--- a/src/scribe_data/extract_transform/languages/Bokmål/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Bokmål/nouns/query_nouns.sparql
@@ -2,7 +2,10 @@
 # Enter this query at https://query.wikidata.org/.
 # Note that this query is for Bokmål (Q25167) rather than Nynorsk (Q25164).
 
-SELECT DISTINCT ?singular ?plural ?gender WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  ?singular ?plural ?gender 
+WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Bokmål/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Bokmål/verbs/query_verbs.sparql
@@ -4,7 +4,8 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-   ?infinitive 
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
+  ?infinitive 
 WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q25167 ;

--- a/src/scribe_data/extract_transform/languages/Bokmål/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Bokmål/verbs/query_verbs.sparql
@@ -2,9 +2,10 @@
 # Enter this query at https://query.wikidata.org/.
 # Note that this query is for Bokmål (Q25167) rather than Nynorsk (Q25164).
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?infinitive 
+  ?infinitive
+
 WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q25167 ;

--- a/src/scribe_data/extract_transform/languages/Bokmål/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Bokmål/verbs/query_verbs.sparql
@@ -4,7 +4,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
   ?infinitive 
 WHERE {
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Bokmål/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Bokmål/verbs/query_verbs.sparql
@@ -2,7 +2,10 @@
 # Enter this query at https://query.wikidata.org/.
 # Note that this query is for Bokmål (Q25167) rather than Nynorsk (Q25164).
 
-SELECT ?lexeme ?infinitive WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+   ?infinitive 
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q25167 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Czech/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Czech/nouns/query_nouns.sparql
@@ -1,8 +1,10 @@
-# All Czeck (Q9056) nouns, their plural and their gender.
+# All Czech (Q9056) nouns, their plural, and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?singular ?plural ?gender WHERE {
-
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  ?singular ?plural ?gender 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Czech/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Czech/nouns/query_nouns.sparql
@@ -1,9 +1,12 @@
 # All Czeck (Q9056) nouns, their plural, and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?singular ?plural ?gender 
+  ?singular
+  ?plural
+  ?gender
+
 WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Czech/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Czech/nouns/query_nouns.sparql
@@ -1,8 +1,9 @@
-# All Czech (Q9056) nouns, their plural, and their gender.
+# All Czeck (Q9056) nouns, their plural, and their gender.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
   ?singular ?plural ?gender 
 WHERE {
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Czech/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Czech/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
   ?singular ?plural ?gender 
 WHERE {
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Czech/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/extract_transform/languages/Czech/prepositions/query_prepositions.sparql
@@ -1,8 +1,10 @@
 # All Czech (Q9056) prepositions and their corresponding cases.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?preposition ?case WHERE {
-
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  ?preposition ?case
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9056 ;
     wikibase:lexicalCategory wd:Q4833830 ;

--- a/src/scribe_data/extract_transform/languages/Czech/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/extract_transform/languages/Czech/prepositions/query_prepositions.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
   ?preposition ?case
 WHERE {
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Czech/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/extract_transform/languages/Czech/prepositions/query_prepositions.sparql
@@ -3,6 +3,7 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
   ?preposition ?case
 WHERE {
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Czech/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/extract_transform/languages/Czech/prepositions/query_prepositions.sparql
@@ -1,9 +1,11 @@
 # All Czech (Q9056) prepositions and their corresponding cases.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?preposition ?case
+  ?preposition
+  ?case
+
 WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9056 ;

--- a/src/scribe_data/extract_transform/languages/Czech/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Czech/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
   ?infinitive WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9056 ;

--- a/src/scribe_data/extract_transform/languages/Czech/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Czech/verbs/query_verbs.sparql
@@ -3,7 +3,8 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?infinitive ?tenseLabel
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
+  ?infinitive WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9056 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Czech/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Czech/verbs/query_verbs.sparql
@@ -1,7 +1,9 @@
 # All Czech (Q9056) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?infinitive  WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  ?infinitive ?tenseLabel
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9056 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Czech/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Czech/verbs/query_verbs.sparql
@@ -1,9 +1,11 @@
 # All Czech (Q9056) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?infinitive WHERE {
+  ?infinitive
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9056 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Danish/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Danish/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
   ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Danish/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Danish/nouns/query_nouns.sparql
@@ -1,10 +1,11 @@
 # All Danish (Q9035) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?singular ?plural ?gender
-WHERE {
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
+  ?singular ?plural ?gender WHERE {
+
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Danish/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Danish/nouns/query_nouns.sparql
@@ -1,8 +1,10 @@
 # All Danish (Q9035) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?singular ?plural ?gender WHERE {
-
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  ?singular ?plural ?gender
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Danish/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Danish/nouns/query_nouns.sparql
@@ -1,10 +1,13 @@
 # All Danish (Q9035) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?singular ?plural ?gender WHERE {
+  ?singular
+  ?plural
+  ?gender
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Danish/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Danish/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
   ?infinitive WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9035 ;

--- a/src/scribe_data/extract_transform/languages/Danish/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Danish/verbs/query_verbs.sparql
@@ -3,7 +3,8 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC ?infinitive WHERE {
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
+  ?infinitive WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9035 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Danish/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Danish/verbs/query_verbs.sparql
@@ -1,7 +1,9 @@
 # All Danish (Q9035) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?infinitive WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC ?infinitive WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9035 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Danish/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Danish/verbs/query_verbs.sparql
@@ -1,9 +1,11 @@
 # All Danish (Q9035) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?infinitive WHERE {
+  ?infinitive
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9035 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/English/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/English/nouns/query_nouns.sparql
@@ -1,10 +1,12 @@
 # All English (Q1860) nouns and their plural.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?singular ?plural WHERE {
+  ?singular
+  ?plural
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/English/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/English/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All English (Q1860) nouns and their plural.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?singular ?plural WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?singular ?plural WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/English/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/English/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?singular ?plural WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/English/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/English/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All English (Q1860) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?infinitive ?presFPS ?presTPS ?simpPast ?pastPart WHERE {
+SELECT DISTINCT  
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
+?infinitive ?presFPS ?presTPS ?simpPast ?pastPart WHERE {
   # Infinitive (required)
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q1860 ;

--- a/src/scribe_data/extract_transform/languages/English/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/English/verbs/query_verbs.sparql
@@ -3,8 +3,7 @@
 
 SELECT DISTINCT  
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC
-?infinitive ?presFPS ?presTPS ?simpPast ?pastPart WHERE {
+  ?infinitive ?presFPS ?presTPS ?simpPast ?pastPart WHERE {
   # Infinitive (required)
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q1860 ;

--- a/src/scribe_data/extract_transform/languages/English/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/English/verbs/query_verbs.sparql
@@ -1,9 +1,15 @@
 # All English (Q1860) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT  
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?infinitive ?presFPS ?presTPS ?simpPast ?pastPart WHERE {
+  ?infinitive
+  ?presFPS
+  ?presTPS
+  ?simpPast
+  ?pastPart
+
+WHERE {
   # Infinitive (required)
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q1860 ;

--- a/src/scribe_data/extract_transform/languages/Esperanto/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Esperanto/nouns/query_nouns.sparql
@@ -1,10 +1,12 @@
 # All Esperanto (Q143) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
-  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID) 
-  ?singular ?plural WHERE {
+SELECT DISTINCT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  ?singular
+  ?plural
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Esperanto/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Esperanto/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Esperanto (Q143) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?singular ?plural WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?singular ?plural WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Esperanto/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Esperanto/nouns/query_nouns.sparql
@@ -2,8 +2,7 @@
 # Enter this query at https://query.wikidata.org/.
 
 SELECT DISTINCT 
-  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID) 
   ?singular ?plural WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Esperanto/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Esperanto/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All Esperanto (Q143) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?verb WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC  
+  ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q143 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Esperanto/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Esperanto/verbs/query_verbs.sparql
@@ -1,9 +1,11 @@
 # All Esperanto (Q143) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?verb WHERE {
+  ?verb
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q143 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Esperanto/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Esperanto/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC  
   ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q143 ;

--- a/src/scribe_data/extract_transform/languages/Estonian/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Estonian/nouns/query_nouns.sparql
@@ -1,10 +1,12 @@
 # All Estonian (Q9072) nouns and their plural.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?singular ?plural WHERE {
+  ?singular
+  ?plural
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Estonian/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Estonian/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Estonian (Q9072) nouns and their plural.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?singular ?plural WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?singular ?plural WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Estonian/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Estonian/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?singular ?plural WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Estonian/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/extract_transform/languages/Estonian/prepositions/query_prepositions.sparql
@@ -2,10 +2,12 @@
 # Enter this query at https://query.wikidata.org/.
 # Note that this query includes postpositions that are also used in Estonian.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?preposition ?case WHERE {
+  ?preposition
+  ?case
 
+WHERE {
   # Prepositions and postpositions.
   VALUES ?PrePostPositions { wd:Q4833830 wd:Q161873 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Estonian/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/extract_transform/languages/Estonian/prepositions/query_prepositions.sparql
@@ -2,7 +2,10 @@
 # Enter this query at https://query.wikidata.org/.
 # Note that this query includes postpositions that are also used in Estonian.
 
-SELECT ?lexeme ?preposition ?case WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC  
+  ?preposition ?case WHERE {
 
   # Prepositions and postpositions.
   VALUES ?PrePostPositions { wd:Q4833830 wd:Q161873 }

--- a/src/scribe_data/extract_transform/languages/Estonian/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/extract_transform/languages/Estonian/prepositions/query_prepositions.sparql
@@ -4,7 +4,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC  
   ?preposition ?case WHERE {
 
   # Prepositions and postpositions.

--- a/src/scribe_data/extract_transform/languages/Estonian/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Estonian/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC  
   ?infinitive  WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9072 ;

--- a/src/scribe_data/extract_transform/languages/Estonian/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Estonian/verbs/query_verbs.sparql
@@ -1,9 +1,11 @@
 # All Estonian (Q9072) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?infinitive  WHERE {
+  ?infinitive
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9072 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Estonian/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Estonian/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All Estonian (Q9072) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?infinitive  WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC  
+  ?infinitive  WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9072 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Finnish/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Finnish/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Finnish (Q1412) nouns and their plural.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?lexeme ?singular ?plural WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC  
+  ?singular ?plural WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Finnish/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Finnish/nouns/query_nouns.sparql
@@ -1,10 +1,12 @@
 # All Finnish (Q1412) nouns and their plural.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?singular ?plural WHERE {
+  ?singular
+  ?plural
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Finnish/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Finnish/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC  
   ?singular ?plural WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Finnish/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Finnish/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q1412 ;

--- a/src/scribe_data/extract_transform/languages/Finnish/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Finnish/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All Finnish (Q1412) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?verb WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q1412 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Finnish/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Finnish/verbs/query_verbs.sparql
@@ -1,9 +1,11 @@
 # All Finnish (Q1412) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?verb WHERE {
+  ?verb
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q1412 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/French/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/French/nouns/query_nouns.sparql
@@ -1,10 +1,13 @@
 # All French (Q150) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?singular ?plural ?gender WHERE {
+  ?singular
+  ?plural
+  ?gender
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/French/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/French/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All French (Q150) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?singular ?plural ?gender WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/French/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/French/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/French/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/extract_transform/languages/French/verbs/query_verbs_1.sparql
@@ -3,7 +3,6 @@
 
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive
   ?presFPS ?presSPS ?presTPS
   ?presFPP ?presSPP ?presTPP

--- a/src/scribe_data/extract_transform/languages/French/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/extract_transform/languages/French/verbs/query_verbs_1.sparql
@@ -2,6 +2,8 @@
 # Enter this query at https://query.wikidata.org/.
 
 SELECT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive
   ?presFPS ?presSPS ?presTPS
   ?presFPP ?presSPP ?presTPP

--- a/src/scribe_data/extract_transform/languages/French/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/extract_transform/languages/French/verbs/query_verbs_1.sparql
@@ -7,8 +7,9 @@ SELECT
   ?presFPS ?presSPS ?presTPS
   ?presFPP ?presSPP ?presTPP
   ?pretFPS ?pretSPS ?pretTPS
-  ?pretFPP ?pretSPP ?pretTPP WHERE {
+  ?pretFPP ?pretSPP ?pretTPP
 
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q150 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/French/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/extract_transform/languages/French/verbs/query_verbs_2.sparql
@@ -7,8 +7,9 @@ SELECT
   ?impFPS ?impSPS ?impTPS
   ?impFPP ?impSPP ?impTPP
   ?futFPS ?futSPS ?futTPS
-  ?futFPP ?futSPP ?futTPP WHERE {
+  ?futFPP ?futSPP ?futTPP
 
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q150 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/French/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/extract_transform/languages/French/verbs/query_verbs_2.sparql
@@ -3,7 +3,6 @@
 
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive
   ?impFPS ?impSPS ?impTPS
   ?impFPP ?impSPP ?impTPP

--- a/src/scribe_data/extract_transform/languages/French/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/extract_transform/languages/French/verbs/query_verbs_2.sparql
@@ -2,6 +2,8 @@
 # Enter this query at https://query.wikidata.org/.
 
 SELECT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive
   ?impFPS ?impSPS ?impTPS
   ?impFPP ?impSPP ?impTPP

--- a/src/scribe_data/extract_transform/languages/German/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/German/nouns/query_nouns.sparql
@@ -1,10 +1,13 @@
 # All German (Q188) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?singular ?plural ?gender WHERE {
+  ?singular
+  ?plural
+  ?gender
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/German/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/German/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All German (Q188) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?singular ?plural ?gender WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/German/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/German/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/German/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/extract_transform/languages/German/prepositions/query_prepositions.sparql
@@ -1,7 +1,10 @@
 # All German (Q188) prepositions and their corresponding cases.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?preposition ?case WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?preposition ?case WHERE {
 
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q188 ;

--- a/src/scribe_data/extract_transform/languages/German/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/extract_transform/languages/German/prepositions/query_prepositions.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?preposition ?case WHERE {
 
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/German/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/extract_transform/languages/German/prepositions/query_prepositions.sparql
@@ -1,10 +1,12 @@
 # All German (Q188) prepositions and their corresponding cases.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?preposition ?case WHERE {
+  ?preposition
+  ?case
 
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q188 ;
     wikibase:lexicalCategory wd:Q4833830 ;

--- a/src/scribe_data/extract_transform/languages/German/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/extract_transform/languages/German/verbs/query_verbs_1.sparql
@@ -6,8 +6,9 @@ SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
   ?infinitive
   ?presFPS ?presSPS ?presTPS
-  ?presFPP ?presSPP ?presTPP WHERE {
+  ?presFPP ?presSPP ?presTPP
 
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q188 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/German/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/extract_transform/languages/German/verbs/query_verbs_1.sparql
@@ -4,7 +4,6 @@
 # Not SELECT DISTINCT as we want to get verbs with both sein and haben as auxiliaries
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive
   ?presFPS ?presSPS ?presTPS
   ?presFPP ?presSPP ?presTPP WHERE {

--- a/src/scribe_data/extract_transform/languages/German/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/extract_transform/languages/German/verbs/query_verbs_1.sparql
@@ -3,6 +3,8 @@
 
 # Not SELECT DISTINCT as we want to get verbs with both sein and haben as auxiliaries
 SELECT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive
   ?presFPS ?presSPS ?presTPS
   ?presFPP ?presSPP ?presTPP WHERE {

--- a/src/scribe_data/extract_transform/languages/German/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/extract_transform/languages/German/verbs/query_verbs_2.sparql
@@ -6,8 +6,9 @@ SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
   ?infinitive ?pastParticiple ?auxiliaryVerb
   ?pretFPS ?pretSPS ?pretTPS
-  ?pretFPP ?pretSPP ?pretTPP WHERE {
+  ?pretFPP ?pretSPP ?pretTPP
 
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q188 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/German/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/extract_transform/languages/German/verbs/query_verbs_2.sparql
@@ -3,6 +3,8 @@
 
 # Not SELECT DISTINCT as we want to get verbs with both sein and haben as auxiliaries
 SELECT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive ?pastParticiple ?auxiliaryVerb
   ?pretFPS ?pretSPS ?pretTPS
   ?pretFPP ?pretSPP ?pretTPP WHERE {

--- a/src/scribe_data/extract_transform/languages/German/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/extract_transform/languages/German/verbs/query_verbs_2.sparql
@@ -4,7 +4,6 @@
 # Not SELECT DISTINCT as we want to get verbs with both sein and haben as auxiliaries
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive ?pastParticiple ?auxiliaryVerb
   ?pretFPS ?pretSPS ?pretTPS
   ?pretFPP ?pretSPP ?pretTPP WHERE {

--- a/src/scribe_data/extract_transform/languages/Greek/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Greek/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Greek (Q36510) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?singular ?plural ?gender WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Greek/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Greek/nouns/query_nouns.sparql
@@ -1,10 +1,13 @@
 # All Greek (Q36510) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?singular ?plural ?gender WHERE {
+  ?singular
+  ?plural
+  ?gender
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Greek/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Greek/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Greek/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Greek/verbs/query_verbs.sparql
@@ -1,4 +1,4 @@
-# All Japanese (Q5287) verbs.
+# All Greek (Q36510) verbs.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT
@@ -7,11 +7,7 @@ SELECT
 
 WHERE {
   ?lexeme a ontolex:LexicalEntry ;
-    dct:language wd:Q5287 ;
+    dct:language wd:Q36510 ;
     wikibase:lexicalCategory wd:Q24905 ;
     wikibase:lemma ?verb .
-
-  BIND(lang(?noun) as ?language)
-  FILTER(?language = "ja-hira")
-  # FILTER(?language = "ja")
 }

--- a/src/scribe_data/extract_transform/languages/Hausa/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Hausa/nouns/query_nouns.sparql
@@ -1,10 +1,12 @@
 # All Hausa (Q56475) nouns and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?noun ?gender WHERE {
+  ?noun
+  ?gender
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Hausa/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Hausa/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Hausa (Q56475) nouns and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?noun ?gender WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?noun ?gender WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Hausa/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Hausa/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?noun ?gender WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Hausa/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Hausa/verbs/query_verbs.sparql
@@ -1,9 +1,11 @@
 # All Hausa (Q56475) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT   
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?verb WHERE {
+  ?verb
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q56475 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Hausa/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Hausa/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT   
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q56475 ;

--- a/src/scribe_data/extract_transform/languages/Hausa/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Hausa/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All Hausa (Q56475) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?verb WHERE {
+SELECT   
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q56475 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Hebrew/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Hebrew/nouns/query_nouns.sparql
@@ -1,10 +1,12 @@
 # All Hebrew (Q9288) nouns and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?noun ?gender WHERE {
+  ?noun
+  ?gender
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Hebrew/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Hebrew/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Hebrew (Q9288) nouns and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?noun ?gender WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?noun ?gender WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Hebrew/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Hebrew/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?noun ?gender WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Hebrew/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Hebrew/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All Hebrew (Q9288) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?verb WHERE {
+SELECT   
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9288 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Hebrew/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Hebrew/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT   
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9288 ;

--- a/src/scribe_data/extract_transform/languages/Hebrew/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Hebrew/verbs/query_verbs.sparql
@@ -1,9 +1,11 @@
 # All Hebrew (Q9288) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT   
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?verb WHERE {
+  ?verb
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9288 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Hindi/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Hindi/nouns/query_nouns.sparql
@@ -2,10 +2,12 @@
 # Enter this query at https://query.wikidata.org/.
 # Note the necessity to filter for "hi" to remove Urdu (ur) words.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?noun ?gender WHERE {
+  ?noun
+  ?gender
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Hindi/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Hindi/nouns/query_nouns.sparql
@@ -4,7 +4,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?noun ?gender WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Hindi/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Hindi/nouns/query_nouns.sparql
@@ -2,7 +2,10 @@
 # Enter this query at https://query.wikidata.org/.
 # Note the necessity to filter for "hi" to remove Urdu (ur) words.
 
-SELECT DISTINCT ?noun ?gender WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?noun ?gender WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Hindi/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Hindi/verbs/query_verbs.sparql
@@ -4,7 +4,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q11051 ;

--- a/src/scribe_data/extract_transform/languages/Hindi/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Hindi/verbs/query_verbs.sparql
@@ -2,7 +2,10 @@
 # Enter this query at https://query.wikidata.org/.
 # Note the necessity to filter for "hi" to remove Urdu (ur) words.
 
-SELECT ?lexeme ?verb WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q11051 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Hindi/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Hindi/verbs/query_verbs.sparql
@@ -2,9 +2,11 @@
 # Enter this query at https://query.wikidata.org/.
 # Note the necessity to filter for "hi" to remove Urdu (ur) words.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?verb WHERE {
+  ?verb
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q11051 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Indonesian/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Indonesian/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Indonesian (Q9240) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?noun WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?noun WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Indonesian/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Indonesian/nouns/query_nouns.sparql
@@ -1,10 +1,11 @@
 # All Indonesian (Q9240) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?noun WHERE {
+  ?noun
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Indonesian/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Indonesian/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?noun WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Indonesian/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Indonesian/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9240 ;

--- a/src/scribe_data/extract_transform/languages/Indonesian/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Indonesian/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All Indonesian (Q9240) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?verb WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9240 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Indonesian/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Indonesian/verbs/query_verbs.sparql
@@ -1,9 +1,11 @@
 # All Indonesian (Q9240) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?verb WHERE {
+  ?verb
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9240 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Italian/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Italian/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Italian (Q652) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?singular ?plural ?gender WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Italian/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Italian/nouns/query_nouns.sparql
@@ -1,10 +1,13 @@
 # All Italian (Q652) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?singular ?plural ?gender WHERE {
+  ?singular
+  ?plural
+  ?gender
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Italian/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Italian/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Italian/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/extract_transform/languages/Italian/verbs/query_verbs_1.sparql
@@ -7,8 +7,9 @@ SELECT
   ?presFPS ?presSPS ?presTPS
   ?presFPP ?presSPP ?presTPP
   ?pretFPS ?pretSPS ?pretTPS
-  ?pretFPP ?pretSPP ?pretTPP WHERE {
+  ?pretFPP ?pretSPP ?pretTPP
 
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q652 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Italian/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/extract_transform/languages/Italian/verbs/query_verbs_1.sparql
@@ -3,7 +3,6 @@
 
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive
   ?presFPS ?presSPS ?presTPS
   ?presFPP ?presSPP ?presTPP

--- a/src/scribe_data/extract_transform/languages/Italian/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/extract_transform/languages/Italian/verbs/query_verbs_1.sparql
@@ -2,6 +2,8 @@
 # Enter this query at https://query.wikidata.org/.
 
 SELECT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive
   ?presFPS ?presSPS ?presTPS
   ?presFPP ?presSPP ?presTPP

--- a/src/scribe_data/extract_transform/languages/Italian/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/extract_transform/languages/Italian/verbs/query_verbs_2.sparql
@@ -3,7 +3,6 @@
 
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive
   ?impFPS ?impSPS ?impTPS
   ?impFPP ?impSPP ?impTPP WHERE {

--- a/src/scribe_data/extract_transform/languages/Italian/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/extract_transform/languages/Italian/verbs/query_verbs_2.sparql
@@ -5,8 +5,9 @@ SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
   ?infinitive
   ?impFPS ?impSPS ?impTPS
-  ?impFPP ?impSPP ?impTPP WHERE {
+  ?impFPP ?impSPP ?impTPP
 
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q652 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Italian/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/extract_transform/languages/Italian/verbs/query_verbs_2.sparql
@@ -2,6 +2,8 @@
 # Enter this query at https://query.wikidata.org/.
 
 SELECT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive
   ?impFPS ?impSPS ?impTPS
   ?impFPP ?impSPP ?impTPP WHERE {

--- a/src/scribe_data/extract_transform/languages/Japanese/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Japanese/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Japanese (Q5287) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?lexeme ?noun WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?noun WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Japanese/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Japanese/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?noun WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Japanese/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Japanese/nouns/query_nouns.sparql
@@ -1,10 +1,11 @@
 # All Japanese (Q5287) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?noun WHERE {
+  ?noun
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Japanese/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Japanese/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All Japanese (Q5287) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?verb WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q5287 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Japanese/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Japanese/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q5287 ;

--- a/src/scribe_data/extract_transform/languages/Kurmanji/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Kurmanji/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Kurmanji (Q36163) nouns and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?noun ?gender WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?noun ?gender WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Kurmanji/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Kurmanji/nouns/query_nouns.sparql
@@ -1,10 +1,12 @@
 # All Kurmanji (Q36163) nouns and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?noun ?gender WHERE {
+  ?noun
+  ?gender
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Kurmanji/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Kurmanji/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?noun ?gender WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Kurmanji/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Kurmanji/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q36163 ;

--- a/src/scribe_data/extract_transform/languages/Kurmanji/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Kurmanji/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All Kurmanji (Q36163) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?verb WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q36163 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Kurmanji/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Kurmanji/verbs/query_verbs.sparql
@@ -1,9 +1,11 @@
 # All Kurmanji (Q36163) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?verb WHERE {
+  ?verb
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q36163 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Latin/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Latin/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Latin (Q397) nouns and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?noun ?gender WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?noun ?gender WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Latin/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Latin/nouns/query_nouns.sparql
@@ -1,10 +1,12 @@
 # All Latin (Q397) nouns and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?noun ?gender WHERE {
+  ?noun
+  ?gender
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Latin/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Latin/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?noun ?gender WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Latin/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Latin/verbs/query_verbs.sparql
@@ -1,9 +1,11 @@
 # All Latin (Q397) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?verb WHERE {
+  ?verb
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q397 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Latin/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Latin/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All Latin (Q397) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?verb WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q397 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Latin/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Latin/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q397 ;

--- a/src/scribe_data/extract_transform/languages/Malay/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Malay/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?noun WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Malay/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Malay/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Malay (Q9237) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?lexeme ?noun WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?noun WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Malay/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Malay/nouns/query_nouns.sparql
@@ -1,10 +1,11 @@
 # All Malay (Q9237) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?noun WHERE {
+  ?noun
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Malay/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Malay/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9237 ;

--- a/src/scribe_data/extract_transform/languages/Malay/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Malay/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All Malay (Q9237) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?verb WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9237 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Malay/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Malay/verbs/query_verbs.sparql
@@ -1,9 +1,11 @@
 # All Malay (Q9237) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?verb WHERE {
+  ?verb
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9237 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Malayalam/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Malayalam/nouns/query_nouns.sparql
@@ -1,10 +1,11 @@
 # All Malayalam (Q36236) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?noun WHERE {
+  ?noun
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Malayalam/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Malayalam/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Malayalam (Q36236) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?noun WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?noun WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Malayalam/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Malayalam/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?noun WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Malayalam/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Malayalam/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All Malayalam (Q36236) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?verb WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q36236 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Malayalam/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Malayalam/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q36236 ;

--- a/src/scribe_data/extract_transform/languages/Malayalam/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Malayalam/verbs/query_verbs.sparql
@@ -1,9 +1,11 @@
 # All Malayalam (Q36236) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?verb WHERE {
+  ?verb
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q36236 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Mandarin/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Mandarin/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Mandarin Chinese (Q727694) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?lexeme ?noun WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?noun WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Mandarin/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Mandarin/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?noun WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Mandarin/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Mandarin/nouns/query_nouns.sparql
@@ -1,10 +1,11 @@
 # All Mandarin Chinese (Q727694) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?noun WHERE {
+  ?noun
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Mandarin/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Mandarin/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All Mandarin Chinese (Q727694) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?verb WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q727694 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Mandarin/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Mandarin/verbs/query_verbs.sparql
@@ -1,9 +1,11 @@
 # All Mandarin Chinese (Q727694) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?verb WHERE {
+  ?verb
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q727694 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Mandarin/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Mandarin/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q727694 ;

--- a/src/scribe_data/extract_transform/languages/Nynorsk/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Nynorsk/nouns/query_nouns.sparql
@@ -4,7 +4,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Nynorsk/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Nynorsk/nouns/query_nouns.sparql
@@ -2,7 +2,10 @@
 # Enter this query at https://query.wikidata.org/.
 # Note that this query is for Nynorsk (Q25164) rather than Bokmål (Q25167).
 
-SELECT DISTINCT ?singular ?plural ?gender WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Nynorsk/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Nynorsk/nouns/query_nouns.sparql
@@ -2,10 +2,13 @@
 # Enter this query at https://query.wikidata.org/.
 # Note that this query is for Nynorsk (Q25164) rather than Bokmål (Q25167).
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?singular ?plural ?gender WHERE {
+  ?singular
+  ?plural
+  ?gender
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Nynorsk/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Nynorsk/verbs/query_verbs.sparql
@@ -4,7 +4,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q25164 ;

--- a/src/scribe_data/extract_transform/languages/Nynorsk/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Nynorsk/verbs/query_verbs.sparql
@@ -2,9 +2,11 @@
 # Enter this query at https://query.wikidata.org/.
 # Note that this query is for Nynorsk (Q25164) rather than Bokmål (Q25167).
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?infinitive WHERE {
+  ?infinitive
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q25164 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Nynorsk/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Nynorsk/verbs/query_verbs.sparql
@@ -2,7 +2,10 @@
 # Enter this query at https://query.wikidata.org/.
 # Note that this query is for Nynorsk (Q25164) rather than Bokmål (Q25167).
 
-SELECT ?lexeme ?infinitive WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?infinitive WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q25164 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Polish/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Polish/nouns/query_nouns.sparql
@@ -1,10 +1,13 @@
 # All Polish (Q809) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?singular ?plural ?gender WHERE {
+  ?singular
+  ?plural
+  ?gender
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Polish/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Polish/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Polish (Q809) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?singular ?plural ?gender WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Polish/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Polish/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Polish/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Polish/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All Polish (Q809) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?infinitive  WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?infinitive  WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q809 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Polish/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Polish/verbs/query_verbs.sparql
@@ -1,9 +1,11 @@
 # All Polish (Q809) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?infinitive  WHERE {
+  ?infinitive
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q809 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Polish/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Polish/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive  WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q809 ;

--- a/src/scribe_data/extract_transform/languages/Portuguese/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Portuguese/nouns/query_nouns.sparql
@@ -1,10 +1,13 @@
 # All Portuguese (Q5146) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?singular ?plural ?gender WHERE {
+  ?singular
+  ?plural
+  ?gender
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Portuguese/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Portuguese/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Portuguese/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Portuguese/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Portuguese (Q5146) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?singular ?plural ?gender WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Portuguese/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Portuguese/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive
   ?presFPS ?presSPS ?presTPS
   ?presFPP ?presSPP ?presTPP

--- a/src/scribe_data/extract_transform/languages/Portuguese/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Portuguese/verbs/query_verbs.sparql
@@ -2,6 +2,8 @@
 # Enter this query at https://query.wikidata.org/.
 
 SELECT DISTINCT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive
   ?presFPS ?presSPS ?presTPS
   ?presFPP ?presSPP ?presTPP

--- a/src/scribe_data/extract_transform/languages/Portuguese/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Portuguese/verbs/query_verbs.sparql
@@ -11,8 +11,9 @@ SELECT DISTINCT
   ?impFPS ?impSPS ?impTPS
   ?impFPP ?impSPP ?impTPP
   ?fSimpFPS ?fSimpSPS ?fSimpTPS
-  ?fSimpFPP ?fSimpSPP ?fSimpTPP WHERE {
+  ?fSimpFPP ?fSimpSPP ?fSimpTPP
 
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q5146 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Russian/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Russian/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Russian (Q7737) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?singular ?plural ?gender WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Russian/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Russian/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Russian/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Russian/nouns/query_nouns.sparql
@@ -1,10 +1,13 @@
 # All Russian (Q7737) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?singular ?plural ?gender WHERE {
+  ?singular
+  ?plural
+  ?gender
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Russian/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/extract_transform/languages/Russian/prepositions/query_prepositions.sparql
@@ -1,7 +1,10 @@
 # All Russian (Q7737) prepositions and their corresponding cases.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?preposition ?case WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?preposition ?case WHERE {
 
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q7737 ;

--- a/src/scribe_data/extract_transform/languages/Russian/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/extract_transform/languages/Russian/prepositions/query_prepositions.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?preposition ?case WHERE {
 
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Russian/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/extract_transform/languages/Russian/prepositions/query_prepositions.sparql
@@ -1,10 +1,12 @@
 # All Russian (Q7737) prepositions and their corresponding cases.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?preposition ?case WHERE {
+  ?preposition
+  ?case
 
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q7737 ;
     wikibase:lexicalCategory wd:Q4833830 ;

--- a/src/scribe_data/extract_transform/languages/Russian/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Russian/verbs/query_verbs.sparql
@@ -6,8 +6,9 @@ SELECT DISTINCT
   ?infinitive
   ?presFPS ?presSPS ?presTPS
   ?presFPP ?presSPP ?presTPP
-  ?pastFeminine ?pastMasculine ?pastNeutral ?pastPlural WHERE {
+  ?pastFeminine ?pastMasculine ?pastNeutral ?pastPlural
 
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q7737 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Russian/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Russian/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive
   ?presFPS ?presSPS ?presTPS
   ?presFPP ?presSPP ?presTPP

--- a/src/scribe_data/extract_transform/languages/Russian/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Russian/verbs/query_verbs.sparql
@@ -2,6 +2,8 @@
 # Enter this query at https://query.wikidata.org/.
 
 SELECT DISTINCT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive
   ?presFPS ?presSPS ?presTPS
   ?presFPP ?presSPP ?presTPP

--- a/src/scribe_data/extract_transform/languages/Slovak/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Slovak/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Slovak (Q9058) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?singular ?plural ?gender WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Slovak/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Slovak/nouns/query_nouns.sparql
@@ -1,10 +1,11 @@
 # All Slovak (Q9058) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?singular ?plural ?gender WHERE {
+  ?singular ?plural ?gender
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Slovak/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Slovak/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Slovak/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/extract_transform/languages/Slovak/prepositions/query_prepositions.sparql
@@ -1,10 +1,11 @@
 # All Slovak (Q9058) prepositions and their corresponding cases.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?preposition ?case WHERE {
+  ?preposition ?case
 
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9058 ;
     wikibase:lexicalCategory wd:Q4833830 ;

--- a/src/scribe_data/extract_transform/languages/Slovak/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/extract_transform/languages/Slovak/prepositions/query_prepositions.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?preposition ?case WHERE {
 
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Slovak/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/extract_transform/languages/Slovak/prepositions/query_prepositions.sparql
@@ -1,7 +1,10 @@
 # All Slovak (Q9058) prepositions and their corresponding cases.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?preposition ?case WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?preposition ?case WHERE {
 
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9058 ;

--- a/src/scribe_data/extract_transform/languages/Slovak/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Slovak/verbs/query_verbs.sparql
@@ -1,9 +1,11 @@
 # All Slovak (Q9058) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?infinitive  WHERE {
+  ?infinitive
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9058 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Slovak/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Slovak/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive  WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9058 ;

--- a/src/scribe_data/extract_transform/languages/Slovak/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Slovak/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All Slovak (Q9058) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?infinitive  WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?infinitive  WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9058 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Spanish/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Spanish/nouns/query_nouns.sparql
@@ -1,10 +1,13 @@
 # All Spanish (Q1321) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?singular ?plural ?gender WHERE {
+  ?singular
+  ?plural
+  ?gender
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Spanish/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Spanish/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Spanish (Q1321) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?singular ?plural ?gender WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Spanish/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Spanish/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Spanish/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/extract_transform/languages/Spanish/verbs/query_verbs_1.sparql
@@ -2,6 +2,8 @@
 # Enter this query at https://query.wikidata.org/.
 
 SELECT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive
   ?presFPS ?presSPS ?presTPS
   ?presFPP ?presSPP ?presTPP WHERE {

--- a/src/scribe_data/extract_transform/languages/Spanish/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/extract_transform/languages/Spanish/verbs/query_verbs_1.sparql
@@ -5,8 +5,10 @@ SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
   ?infinitive
   ?presFPS ?presSPS ?presTPS
-  ?presFPP ?presSPP ?presTPP WHERE {
+  ?presFPP ?presSPP ?presTPP
 
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q1321 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Spanish/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/extract_transform/languages/Spanish/verbs/query_verbs_1.sparql
@@ -3,7 +3,6 @@
 
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive
   ?presFPS ?presSPS ?presTPS
   ?presFPP ?presSPP ?presTPP WHERE {

--- a/src/scribe_data/extract_transform/languages/Spanish/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/extract_transform/languages/Spanish/verbs/query_verbs_2.sparql
@@ -5,8 +5,9 @@ SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
   ?infinitive
   ?pretFPS ?pretSPS ?pretTPS
-  ?pretFPP ?pretSPP ?pretTPP WHERE {
+  ?pretFPP ?pretSPP ?pretTPP
 
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q1321 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Spanish/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/extract_transform/languages/Spanish/verbs/query_verbs_2.sparql
@@ -3,7 +3,6 @@
 
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive
   ?pretFPS ?pretSPS ?pretTPS
   ?pretFPP ?pretSPP ?pretTPP WHERE {

--- a/src/scribe_data/extract_transform/languages/Spanish/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/extract_transform/languages/Spanish/verbs/query_verbs_2.sparql
@@ -2,6 +2,8 @@
 # Enter this query at https://query.wikidata.org/.
 
 SELECT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive
   ?pretFPS ?pretSPS ?pretTPS
   ?pretFPP ?pretSPP ?pretTPP WHERE {

--- a/src/scribe_data/extract_transform/languages/Spanish/verbs/query_verbs_3.sparql
+++ b/src/scribe_data/extract_transform/languages/Spanish/verbs/query_verbs_3.sparql
@@ -3,7 +3,6 @@
 
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive
   ?impFPS ?impSPS ?impTPS
   ?impFPP ?impSPP ?impTPP WHERE {

--- a/src/scribe_data/extract_transform/languages/Spanish/verbs/query_verbs_3.sparql
+++ b/src/scribe_data/extract_transform/languages/Spanish/verbs/query_verbs_3.sparql
@@ -5,8 +5,9 @@ SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
   ?infinitive
   ?impFPS ?impSPS ?impTPS
-  ?impFPP ?impSPP ?impTPP WHERE {
+  ?impFPP ?impSPP ?impTPP
 
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q1321 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Spanish/verbs/query_verbs_3.sparql
+++ b/src/scribe_data/extract_transform/languages/Spanish/verbs/query_verbs_3.sparql
@@ -2,6 +2,8 @@
 # Enter this query at https://query.wikidata.org/.
 
 SELECT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive
   ?impFPS ?impSPS ?impTPS
   ?impFPP ?impSPP ?impTPP WHERE {

--- a/src/scribe_data/extract_transform/languages/Swedish/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Swedish/nouns/query_nouns.sparql
@@ -4,6 +4,8 @@
 # Note: does not include pronouns as the query wasn't running.
 
 SELECT DISTINCT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?nominativeSingular ?nominativePlural
   ?genitiveSingular ?genitivePlural ?gender WHERE {
 

--- a/src/scribe_data/extract_transform/languages/Swedish/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Swedish/nouns/query_nouns.sparql
@@ -5,7 +5,6 @@
 
 SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?nominativeSingular ?nominativePlural
   ?genitiveSingular ?genitivePlural ?gender WHERE {
 

--- a/src/scribe_data/extract_transform/languages/Swedish/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Swedish/nouns/query_nouns.sparql
@@ -6,8 +6,9 @@
 SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
   ?nominativeSingular ?nominativePlural
-  ?genitiveSingular ?genitivePlural ?gender WHERE {
+  ?genitiveSingular ?genitivePlural ?gender
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Swedish/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Swedish/verbs/query_verbs.sparql
@@ -2,6 +2,8 @@
 # Enter this query at https://query.wikidata.org/.
 
 SELECT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?activeInfinitive ?imperative ?activeSupine
   ?activePresent ?activePreterite
   ?passiveInfinitive ?passiveSupine

--- a/src/scribe_data/extract_transform/languages/Swedish/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Swedish/verbs/query_verbs.sparql
@@ -6,8 +6,9 @@ SELECT
   ?activeInfinitive ?imperative ?activeSupine
   ?activePresent ?activePreterite
   ?passiveInfinitive ?passiveSupine
-  ?passivePresent ?passivePreterite WHERE {
+  ?passivePresent ?passivePreterite
 
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9027 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Swedish/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Swedish/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?activeInfinitive ?imperative ?activeSupine
   ?activePresent ?activePreterite
   ?passiveInfinitive ?passiveSupine

--- a/src/scribe_data/extract_transform/languages/Tajik/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Tajik/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Tajik (Q9260) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?lexeme ?noun WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC  
+  ?noun WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Tajik/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Tajik/nouns/query_nouns.sparql
@@ -1,10 +1,11 @@
 # All Tajik (Q9260) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?noun WHERE {
+  ?noun
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Tajik/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Tajik/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC  
   ?noun WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Tajik/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Tajik/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9260 ;

--- a/src/scribe_data/extract_transform/languages/Tajik/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Tajik/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All Tajik (Q9260) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?verb WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9260 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Tajik/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Tajik/verbs/query_verbs.sparql
@@ -1,9 +1,11 @@
 # All Tajik (Q9260) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?verb WHERE {
+  ?verb
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q9260 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Tamil/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Tamil/nouns/query_nouns.sparql
@@ -1,10 +1,11 @@
 # All Tamil (Q5885) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?noun WHERE {
+  ?noun
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Tamil/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Tamil/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?noun WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Tamil/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Tamil/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Tamil (Q5885) nouns.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?lexeme ?noun WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?noun WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Tamil/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Tamil/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q5885 ;

--- a/src/scribe_data/extract_transform/languages/Tamil/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Tamil/verbs/query_verbs.sparql
@@ -1,9 +1,11 @@
 # All Tamil (Q5885) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?verb WHERE {
+  ?verb
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q5885 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Tamil/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Tamil/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All Tamil (Q5885) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?verb WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q5885 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Ukranian/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Ukranian/nouns/query_nouns.sparql
@@ -1,10 +1,13 @@
 # All Ukrainian (Q8798) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?singular ?plural ?gender WHERE {
+  ?singular
+  ?plural
+  ?gender
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Ukranian/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Ukranian/nouns/query_nouns.sparql
@@ -1,7 +1,10 @@
 # All Ukrainian (Q8798) nouns, their plural and their gender.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?singular ?plural ?gender WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Ukranian/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Ukranian/nouns/query_nouns.sparql
@@ -3,7 +3,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?singular ?plural ?gender WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Ukranian/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/extract_transform/languages/Ukranian/prepositions/query_prepositions.sparql
@@ -1,10 +1,12 @@
 # All Ukrainian (Q8798) prepositions and their corresponding cases.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?preposition ?case WHERE {
+  ?preposition
+  ?case
 
+WHERE {
   # All German prepositions.
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q8798 ;

--- a/src/scribe_data/extract_transform/languages/Ukranian/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/extract_transform/languages/Ukranian/prepositions/query_prepositions.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?preposition ?case WHERE {
 
   # All German prepositions.

--- a/src/scribe_data/extract_transform/languages/Ukranian/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/extract_transform/languages/Ukranian/prepositions/query_prepositions.sparql
@@ -1,7 +1,10 @@
 # All Ukrainian (Q8798) prepositions and their corresponding cases.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?preposition ?case WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?preposition ?case WHERE {
 
   # All German prepositions.
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Ukranian/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Ukranian/verbs/query_verbs.sparql
@@ -1,7 +1,10 @@
 # All Ukrainian (Q8798) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT ?lexeme ?infinitive  WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?infinitive  WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q8798 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Ukranian/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Ukranian/verbs/query_verbs.sparql
@@ -3,7 +3,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?infinitive  WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q8798 ;

--- a/src/scribe_data/extract_transform/languages/Ukranian/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Ukranian/verbs/query_verbs.sparql
@@ -1,9 +1,11 @@
 # All Ukrainian (Q8798) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?infinitive  WHERE {
+  ?infinitive
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q8798 ;
     wikibase:lexicalCategory wd:Q24905 .

--- a/src/scribe_data/extract_transform/languages/Urdu/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Urdu/nouns/query_nouns.sparql
@@ -2,10 +2,12 @@
 # Enter this query at https://query.wikidata.org/.
 # Note the necessity to filter for "ur" to remove Hindustani (hi) words.
 
-SELECT DISTINCT 
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?noun ?gender WHERE {
+  ?noun
+  ?gender
 
+WHERE {
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/languages/Urdu/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Urdu/nouns/query_nouns.sparql
@@ -2,7 +2,10 @@
 # Enter this query at https://query.wikidata.org/.
 # Note the necessity to filter for "ur" to remove Hindustani (hi) words.
 
-SELECT DISTINCT ?noun ?gender WHERE {
+SELECT DISTINCT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?noun ?gender WHERE {
 
   # Nouns and pronouns.
   VALUES ?nounTypes { wd:Q1084 wd:Q147276 }

--- a/src/scribe_data/extract_transform/languages/Urdu/nouns/query_nouns.sparql
+++ b/src/scribe_data/extract_transform/languages/Urdu/nouns/query_nouns.sparql
@@ -4,7 +4,6 @@
 
 SELECT DISTINCT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?noun ?gender WHERE {
 
   # Nouns and pronouns.

--- a/src/scribe_data/extract_transform/languages/Urdu/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Urdu/verbs/query_verbs.sparql
@@ -4,7 +4,6 @@
 
 SELECT 
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
   ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q11051 ;

--- a/src/scribe_data/extract_transform/languages/Urdu/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Urdu/verbs/query_verbs.sparql
@@ -2,9 +2,11 @@
 # Enter this query at https://query.wikidata.org/.
 # Note the necessity to filter for "ur" to remove Hindustani (hi) words.
 
-SELECT 
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
-  ?verb WHERE {
+  ?verb
+
+WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q11051 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/languages/Urdu/verbs/query_verbs.sparql
+++ b/src/scribe_data/extract_transform/languages/Urdu/verbs/query_verbs.sparql
@@ -2,7 +2,10 @@
 # Enter this query at https://query.wikidata.org/.
 # Note the necessity to filter for "ur" to remove Hindustani (hi) words.
 
-SELECT ?lexeme ?verb WHERE {
+SELECT 
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+  OTHER_COLUMS_LIKE_NOUN_OR_VERB_ETC 
+  ?verb WHERE {
   ?lexeme a ontolex:LexicalEntry ;
     dct:language wd:Q11051 ;
     wikibase:lexicalCategory wd:Q24905 ;

--- a/src/scribe_data/extract_transform/query_profanity.sparql
+++ b/src/scribe_data/extract_transform/query_profanity.sparql
@@ -1,7 +1,9 @@
 # Queries all profane words from a given language to be removed from autosuggest options.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT ?lemma
+SELECT DISTINCT 
+ (REPLACE(STR(?lexemeId), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+ ?lemma
 WHERE {
   ?lexemeId dct:language wd:LANGUAGE_QID; # replace language qid here
             wikibase:lemma ?lemma;

--- a/src/scribe_data/extract_transform/query_profanity.sparql
+++ b/src/scribe_data/extract_transform/query_profanity.sparql
@@ -1,9 +1,7 @@
 # Queries all profane words from a given language to be removed from autosuggest options.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT 
- (REPLACE(STR(?lexemeId), "http://www.wikidata.org/entity/", "") as ?lexemeID)
- ?lemma
+SELECT DISTINCT ?lemma
 WHERE {
   ?lexemeId dct:language wd:LANGUAGE_QID; # replace language qid here
             wikibase:lemma ?lemma;

--- a/src/scribe_data/extract_transform/query_words_to_translate.sparql
+++ b/src/scribe_data/extract_transform/query_words_to_translate.sparql
@@ -7,7 +7,9 @@
 # Words with multiple translations could also prompt the keyboard to be replaced with the options.
 # For now words are querried and machine translated using 🤗 Transformers.
 
-SELECT ?word WHERE {
+SELECT 
+ (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
+ ?word WHERE {
   # We want nouns, proper nouns, pronouns, personal pronouns, verbs, adjectives, adverbs, prepositions, postpositions, conjunctions and articles.
   VALUES ?wordCategories { wd:Q1084 wd:Q147276 wd:Q36224 wd:Q468801 wd:Q24905 wd:Q34698 wd:Q380057 wd:Q4833830 wd:Q161873 wd:Q191536 wd:Q103184 }
   ?lexeme a ontolex:LexicalEntry ;

--- a/src/scribe_data/extract_transform/query_words_to_translate.sparql
+++ b/src/scribe_data/extract_transform/query_words_to_translate.sparql
@@ -7,9 +7,7 @@
 # Words with multiple translations could also prompt the keyboard to be replaced with the options.
 # For now words are querried and machine translated using 🤗 Transformers.
 
-SELECT 
- (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)
- ?word WHERE {
+SELECT ?word WHERE {
   # We want nouns, proper nouns, pronouns, personal pronouns, verbs, adjectives, adverbs, prepositions, postpositions, conjunctions and articles.
   VALUES ?wordCategories { wd:Q1084 wd:Q147276 wd:Q36224 wd:Q468801 wd:Q24905 wd:Q34698 wd:Q380057 wd:Q4833830 wd:Q161873 wd:Q191536 wd:Q103184 }
   ?lexeme a ontolex:LexicalEntry ;


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
The `SELECT` statement in the query has been updated to include `(REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") as ?lexemeID)` as the first element. This modification ensures that the query returns the lexeme ID alongside the word category and its counts, aligning with the requirements outlined in the [issue discussion](https://github.com/scribe-org/Scribe-Data/issues/101#issuecomment-1987823785) and the specific approach suggested by [Andrew](https://github.com/scribe-org/Scribe-Data/issues/101#issuecomment-2002506342).


<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- closes #101