### PR TITLE
Article remove from machine translation process with the help of sparql.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
   - Querying Wikidata lexicographical data can be done via the `--query` command ([#159](https://github.com/scribe-org/Scribe-Data/issues/159)).
   - Total Wikidata lexemes for languages and data types can be derived with the `--total` command ([#147](https://github.com/scribe-org/Scribe-Data/issues/147)).
   - Commands can be used via an interactive mode with the `--interactive` command ([#158](https://github.com/scribe-org/Scribe-Data/issues/158)).
+- Articles are removed from machine translations so they're more directly useful in Scribe applications ([#96](https://github.com/scribe-org/Scribe-Data/issues/96)).
 
 ### 🐞 Bug Fixes
 

--- a/src/scribe_data/cli/interactive.py
+++ b/src/scribe_data/cli/interactive.py
@@ -36,12 +36,18 @@ def get_selection(user_input: str, options: List[str]) -> List[str]:
     """
     Parse user input to get selected options.
 
-    Args:
-        user_input (str): User's input string
-        options (List[str]): List of available options
+    Parameters
+    ----------
+        user_input : str
+            The user's input string.
 
-    Returns:
-        List[str]: Selected options
+        options : List[str]
+            The list of available options given the interactive mode stage.
+
+    Returns
+    -------
+        List[str]
+            The options available in interactive mode and CLI directions.
     """
     if user_input.lower() == "a":
         return options
@@ -58,8 +64,10 @@ def select_languages() -> List[str]:
     """
     Display language options and get user selection.
 
-    Returns:
-        list[str]: Selected languages
+    Returns
+    -------
+        List[str]
+            The languages available in Scribe-Data and CLI directions.
     """
     print("Language options:")
     languages = [
@@ -79,8 +87,10 @@ def select_data_types() -> List[str]:
     """
     Display data type options and get user selection.
 
-    Returns:
-        list[str]: Selected data types
+    Returns
+    -------
+        List[str]
+            The data types available in Scribe-Data and CLI directions.
     """
     print("\nData type options:")
     data_types = data_type_metadata["data-types"]
@@ -99,8 +109,10 @@ def get_output_options() -> dict:
     """
     Get output options from user.
 
-    Returns:
-        dict: Output options including type, directory, and overwrite flag
+    Returns
+    -------
+        dict
+            Output options including type, directory, and overwrite flag
     """
     output_type = (
         input("File type to export (json, csv, tsv) [json]: ").lower() or "json"
@@ -120,8 +132,8 @@ def run_interactive_mode():
     """
     Run the interactive mode for Scribe-Data CLI.
 
-    This function guides the user through selecting languages, data types,
-    and output options, then executes the query based on these selections.
+    This function guides the user through selecting languages, data types and output options.
+    The query is then executed based on these selections.
     """
     selected_languages = select_languages()
     selected_data_types = select_data_types()

--- a/src/scribe_data/language_data_extraction/English/translations/translate_words.py
+++ b/src/scribe_data/language_data_extraction/English/translations/translate_words.py
@@ -41,7 +41,7 @@ with open(words_to_translate_path, "r", encoding="utf-8") as file:
 
 word_list = [item["word"] for item in json_data]
 
-translations = {}
+translations = []
 translated_words_path = os.path.join(
     translate_script_dir,
     f"{os.path.dirname(sys.path[0]).split('scribe_data')[0]}/../scribe_data_json_export/{SRC_LANG}/translated_words.json",

--- a/src/scribe_data/language_data_extraction/French/translations/translate_words.py
+++ b/src/scribe_data/language_data_extraction/French/translations/translate_words.py
@@ -41,7 +41,7 @@ with open(words_to_translate_path, "r", encoding="utf-8") as file:
 
 word_list = [item["word"] for item in json_data]
 
-translations = {}
+translations = []
 translated_words_path = os.path.join(
     translate_script_dir,
     f"{os.path.dirname(sys.path[0]).split('scribe_data')[0]}/../scribe_data_json_export/{SRC_LANG}/translated_words.json",

--- a/src/scribe_data/language_data_extraction/German/translations/translate_words.py
+++ b/src/scribe_data/language_data_extraction/German/translations/translate_words.py
@@ -41,7 +41,7 @@ with open(words_to_translate_path, "r", encoding="utf-8") as file:
 
 word_list = [item["word"] for item in json_data]
 
-translations = {}
+translations = []
 translated_words_path = os.path.join(
     translate_script_dir,
     f"{os.path.dirname(sys.path[0]).split('scribe_data')[0]}/../scribe_data_json_export/{SRC_LANG}/translated_words.json",

--- a/src/scribe_data/language_data_extraction/Italian/translations/translate_words.py
+++ b/src/scribe_data/language_data_extraction/Italian/translations/translate_words.py
@@ -41,7 +41,7 @@ with open(words_to_translate_path, "r", encoding="utf-8") as file:
 
 word_list = [item["word"] for item in json_data]
 
-translations = {}
+translations = []
 translated_words_path = os.path.join(
     translate_script_dir,
     f"{os.path.dirname(sys.path[0]).split('scribe_data')[0]}/../scribe_data_json_export/{SRC_LANG}/translated_words.json",

--- a/src/scribe_data/language_data_extraction/Portuguese/translations/translate_words.py
+++ b/src/scribe_data/language_data_extraction/Portuguese/translations/translate_words.py
@@ -41,7 +41,7 @@ with open(words_to_translate_path, "r", encoding="utf-8") as file:
 
 word_list = [item["word"] for item in json_data]
 
-translations = {}
+translations = []
 translated_words_path = os.path.join(
     translate_script_dir,
     f"{os.path.dirname(sys.path[0]).split('scribe_data')[0]}/../scribe_data_json_export/{SRC_LANG}/translated_words.json",

--- a/src/scribe_data/language_data_extraction/Russian/translations/translate_words.py
+++ b/src/scribe_data/language_data_extraction/Russian/translations/translate_words.py
@@ -41,7 +41,7 @@ with open(words_to_translate_path, "r", encoding="utf-8") as file:
 
 word_list = [item["word"] for item in json_data]
 
-translations = {}
+translations = []
 translated_words_path = os.path.join(
     translate_script_dir,
     f"{os.path.dirname(sys.path[0]).split('scribe_data')[0]}/../scribe_data_json_export/{SRC_LANG}/translated_words.json",

--- a/src/scribe_data/language_data_extraction/Spanish/translations/translate_words.py
+++ b/src/scribe_data/language_data_extraction/Spanish/translations/translate_words.py
@@ -41,7 +41,7 @@ with open(words_to_translate_path, "r", encoding="utf-8") as file:
 
 word_list = [item["word"] for item in json_data]
 
-translations = {}
+translations = []
 translated_words_path = os.path.join(
     translate_script_dir,
     f"{os.path.dirname(sys.path[0]).split('scribe_data')[0]}/../scribe_data_json_export/{SRC_LANG}/translated_words.json",

--- a/src/scribe_data/language_data_extraction/Swedish/translations/translate_words.py
+++ b/src/scribe_data/language_data_extraction/Swedish/translations/translate_words.py
@@ -41,7 +41,7 @@ with open(words_to_translate_path, "r", encoding="utf-8") as file:
 
 word_list = [item["word"] for item in json_data]
 
-translations = {}
+translations = []
 translated_words_path = os.path.join(
     translate_script_dir,
     f"{os.path.dirname(sys.path[0]).split('scribe_data')[0]}/../scribe_data_json_export/{SRC_LANG}/translated_words.json",

--- a/src/scribe_data/translation/translation_utils.py
+++ b/src/scribe_data/translation/translation_utils.py
@@ -24,13 +24,76 @@ import json
 import os
 import signal
 import sys
+from functools import lru_cache
+from typing import List
+from pathlib import Path
 
 from transformers import M2M100ForConditionalGeneration, M2M100Tokenizer
+from scribe_data.wikidata.wikidata_utils import JSON, sparql
 
 from scribe_data.utils import (
     get_language_iso,
     get_target_langcodes,
 )
+
+LANGUAGE_METADATA_FILE = (
+    Path(__file__).parent.parent / "resources" / "language_metadata.json"
+)
+
+with LANGUAGE_METADATA_FILE.open("r", encoding="utf-8") as file:
+    language_data = json.load(file)
+
+
+@lru_cache(maxsize=None)
+def get_language_qid(language_name: str) -> str:
+    """Get the QID for a given language name."""
+    normalized_name = language_name.lower()
+    for language in language_data["languages"]:
+        if language["language"] == normalized_name:
+            return language["qid"]
+    return None
+
+
+@lru_cache(maxsize=None)
+def get_all_articles(language: str) -> List[str]:
+    """Get all articles for a given language."""
+    qid_from_language_metadata = get_language_qid(language)
+    query = f"""
+    SELECT DISTINCT ?article WHERE {{
+      VALUES ?language {{ wd:{qid_from_language_metadata} }}
+      ?lexeme dct:language ?language ;
+              wikibase:lexicalCategory ?category ;
+              wikibase:lemma ?lemma .
+      VALUES ?category {{ wd:Q2865743 wd:Q3813849 wd:Q576670}}  # Definite, indefinite articles and Partitive Articles
+
+      {{
+        ?lexeme wikibase:lemma ?article .
+      }} UNION {{
+        ?lexeme ontolex:lexicalForm ?form .
+        ?form ontolex:representation ?article .
+      }}
+    }}
+    """
+
+    sparql.setQuery(query)
+    sparql.setReturnFormat(JSON)
+    results = sparql.query().convert()
+    return [result["article"]["value"] for result in results["results"]["bindings"]]
+
+
+def remove_articles_from_words(
+    batch_words: List[str], articles: List[str]
+) -> List[str]:
+    """Remove articles from a given list of words."""
+
+    def remove_article(word: str) -> str:
+        for article in articles:
+            if word.lower().startswith(article.lower() + " "):
+                print(f"Article '{article}' found in word: '{word}'")
+                return word[len(article) :].strip()
+        return word
+
+    return [remove_article(word) for word in batch_words]
 
 
 def translation_interrupt_handler(source_language, translations):
@@ -72,8 +135,8 @@ def translate_to_other_languages(source_language, word_list, translations, batch
         word_list : list[str]
             The list of words to translate.
 
-        translations : dict
-            The current dictionary of translations.
+        translations : list
+            The current list of translation dictionaries.
 
         batch_size : int
             The number of words to translate in each batch.
@@ -85,9 +148,11 @@ def translate_to_other_languages(source_language, word_list, translations, batch
         signal.SIGINT,
         lambda sig, frame: translation_interrupt_handler(source_language, translations),
     )
+    articles = get_all_articles(source_language)
 
     for i in range(0, len(word_list), batch_size):
         batch_words = word_list[i : i + batch_size]
+        batch_words = remove_articles_from_words(batch_words, articles)
         print(f"Translating batch {i//batch_size + 1}: {batch_words}")
 
         for lang_code in get_target_langcodes(source_language):
@@ -101,10 +166,19 @@ def translate_to_other_languages(source_language, word_list, translations, batch
             )
 
             for word, translation in zip(batch_words, translated_words):
-                if word not in translations:
-                    translations[word] = {}
+                "Find if the word already exists in translations"
+                existing_entry = next(
+                    (item for item in translations if word in item), None
+                )
 
-                translations[word][lang_code] = translation
+                if existing_entry is None:
+                    "If the word doesn't exist, create a new entry"
+                    new_entry = {word: {lang_code: translation}}
+                    translations.append(new_entry)
+
+                else:
+                    "If the word exists, update its translations"
+                    existing_entry[word][lang_code] = translation
 
         print(f"Batch {i//batch_size + 1} translation completed.")
 

--- a/src/scribe_data/utils.py
+++ b/src/scribe_data/utils.py
@@ -25,7 +25,7 @@ import json
 import os
 import sys
 from importlib import resources
-from typing import Any
+from typing import Any, List
 
 from iso639 import Lang
 from iso639.exceptions import DeprecatedLanguageValue, InvalidLanguageValue
@@ -116,7 +116,7 @@ def _find(source_key: str, source_value: str, target_key: str, error_msg: str):
     raise ValueError(error_msg)
 
 
-def get_scribe_languages() -> list[str]:
+def get_scribe_languages() -> List[str]:
     """
     Returns the list of currently implemented Scribe languages.
     """
@@ -191,7 +191,7 @@ def get_language_from_iso(iso: str) -> str:
     return language_name
 
 
-def get_language_words_to_remove(language: str) -> list[str]:
+def get_language_words_to_remove(language: str) -> List[str]:
     """
     Returns the words that should be removed during the data cleaning process for the given language.
 
@@ -202,7 +202,7 @@ def get_language_words_to_remove(language: str) -> list[str]:
 
     Returns
     -------
-        list[str]
+        List[str]
             The words that that be removed during the data cleaning process for the given language.
     """
     return _find(
@@ -213,7 +213,7 @@ def get_language_words_to_remove(language: str) -> list[str]:
     )
 
 
-def get_language_words_to_ignore(language: str) -> list[str]:
+def get_language_words_to_ignore(language: str) -> List[str]:
     """
     Returns the words that should not be included as autosuggestions for the given language.
 
@@ -224,7 +224,7 @@ def get_language_words_to_ignore(language: str) -> list[str]:
 
     Returns
     -------
-        list[str]
+        List[str]
             The words that should not be included as autosuggestions for the given language.
     """
     return _find(
@@ -335,8 +335,8 @@ def get_ios_data_path(language: str) -> str:
 
 
 def check_command_line_args(
-    file_name: str, passed_values: Any, values_to_check: list[str]
-) -> list[str]:
+    file_name: str, passed_values: Any, values_to_check: List[str]
+) -> List[str]:
     """
     Checks command line arguments passed to Scribe-Data files.
 
@@ -444,7 +444,7 @@ def check_and_return_command_line_args(
     )
 
 
-def get_target_langcodes(source_lang) -> list[str]:
+def get_target_langcodes(source_lang) -> List[str]:
     """
     Returns a list of target language ISO codes for translation.
 
@@ -455,7 +455,7 @@ def get_target_langcodes(source_lang) -> list[str]:
 
     Returns
     -------
-        list[str]
+        List[str]
             A list of target language ISO codes.
     """
     return [


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

When i try to run `Scribe-Data/src/scribe_data/language_data_extraction/English/translations$` `python3.9 translate_words.py
` It gives me this error message,

```
Traceback (most recent call last):
  File "/media/asif/Scribe-Data/src/scribe_data/language_data_extraction/English/translations/translate_words.py", line 54, in <module>
    translate_to_other_languages(
  File "/media/asif/Scribe-Data/src/scribe_data/translation/translation_utils.py", line 105, in translate_to_other_languages
    translations[word] = {}
TypeError: list indices must be integers or slices, not str
(venv) asif@asif-X450LA:/media/asif/Mahbub11/Scribe-Data/src/scribe_data/language_data_extraction/English/translations$ 
```

Therefore, after realizing this, i modify the [code](https://github.com/axif0/Scribe-Data/blob/b6b85c168bb77056ff586c952e434496b253e1a5/src/scribe_data/translation/translation_utils.py#L171) to match  [scribe_data_json_export](https://github.com/scribe-org/Scribe-Data/tree/64eb52b0be2d4fe7d9f212d733c602463c79046d/scribe_data_json_export) . 

> Qid Can be taken from `Cli_utils`, but sadly couldn't see a function. That's why I called it again. 



![image](https://github.com/user-attachments/assets/ba5c421e-5a11-4970-a764-df0933d9c5ef)

I'm extremely sorry for not testing all the languages and not even fully completely test for one language, my potato old pc couldn't handled it. :( 

I'm not sure about the Partitive Articles, In french articles, i see SPARQL query for French articles returns:
tout, le, un, l', toute, toutes, tous, la, les, une

It's missing:
1. Indefinite plural "des"
2. Partitive articles "du," "de la," "de l'"

How can I modify the query to include these compound articles? Are they represented differently in Wikidata? Or am I in the right path?

### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #96
 