### PR TITLE
Fix: Update function call from upgrade_cli to upgrade

### DIFF
--- a/src/scribe_data/cli/main.py
+++ b/src/scribe_data/cli/main.py
@@ -28,7 +28,7 @@ from scribe_data.cli.get import get_data
 from scribe_data.cli.interactive import start_interactive_mode
 from scribe_data.cli.list import list_wrapper
 from scribe_data.cli.total import get_total_lexemes
-from scribe_data.cli.upgrade import upgrade_cli
+from scribe_data.cli.upgrade import upgrade
 from scribe_data.cli.version import get_version_message
 
 LIST_DESCRIPTION = "List languages, data types and combinations of each that Scribe-Data can be used for."
@@ -196,7 +196,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.upgrade:
-        upgrade_cli()
+        upgrade()
         return
 
     if not args.command:


### PR DESCRIPTION
### Contributor checklist
- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
The main.py function is referencing the `upgrade_cli` in the upgrade.py file, 

Previous referenced Code lines
**Main.py:**
- https://github.com/scribe-org/Scribe-Data/blob/a072b52ba4ab627cf32714dd6587b0861ff1feb5/src/scribe_data/cli/main.py#L31
- https://github.com/scribe-org/Scribe-Data/blob/a072b52ba4ab627cf32714dd6587b0861ff1feb5/src/scribe_data/cli/main.py#L199

**Upgrade.py:**
- https://github.com/scribe-org/Scribe-Data/blob/a072b52ba4ab627cf32714dd6587b0861ff1feb5/src/scribe_data/cli/upgrade.py#L35

Now, the reference is fixed with the actual function names --> `upgrade()`
**Main.py:**
- https://github.com/scribe-org/Scribe-Data/blob/4e2f48c785ab19fd475dce8c7c1326269bd751de/src/scribe_data/cli/main.py#L31
- https://github.com/scribe-org/Scribe-Data/blob/4e2f48c785ab19fd475dce8c7c1326269bd751de/src/scribe_data/cli/main.py#L199

### Related issue
- #188 
