### PR TITLE
Expand Danish verb query

### DIFF
--- a/src/scribe_data/language_data_extraction/Danish/verbs/query_verbs.sparql
+++ b/src/scribe_data/language_data_extraction/Danish/verbs/query_verbs.sparql
@@ -2,7 +2,7 @@
 # All Danish (Q9035) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?infinitive
   ?infActive

--- a/src/scribe_data/language_data_extraction/Danish/verbs/query_verbs.sparql
+++ b/src/scribe_data/language_data_extraction/Danish/verbs/query_verbs.sparql
@@ -2,7 +2,7 @@
 # All Danish (Q9035) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?infinitive
   ?infActive
@@ -15,14 +15,15 @@ SELECT DISTINCT
   ?pretPassive
   ?infPassive
 
-
 WHERE {
-  # Infinitive
+  # MARK: Infinitive
+
   ?lexeme dct:language wd:Q9035 ;
     wikibase:lexicalCategory wd:Q24905 ;
     wikibase:lemma ?infinitive
 
   # MARK: Infinitive Active
+
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?infActiveForm .
     ?infActiveForm ontolex:representation ?infActive ;
@@ -30,7 +31,8 @@ WHERE {
       wikibase:grammaticalFeature wd:Q1317831 .
   }
 
-  # MARK: Present Tense Active
+  # MARK: Present Active
+
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presActiveForm .
     ?presActiveForm ontolex:representation ?presActive ;
@@ -39,6 +41,7 @@ WHERE {
   }
 
   # MARK: Preterite Active
+
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pretActiveForm .
     ?pretActiveForm ontolex:representation ?pretActive ;
@@ -47,6 +50,7 @@ WHERE {
   }
 
   # MARK: Past Participle
+
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pastPartForm .
     ?pastPartForm ontolex:representation ?pastPart ;
@@ -54,6 +58,7 @@ WHERE {
   }
 
   # MARK: Present Participle
+
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presPartForm .
     ?presPartForm ontolex:representation ?presPart ;
@@ -61,6 +66,7 @@ WHERE {
   }
 
   # MARK: Imperative
+
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?imperativeForm .
     ?imperativeForm ontolex:representation ?imperative ;
@@ -68,6 +74,7 @@ WHERE {
   }
 
   # MARK: Present Passive
+
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presPassiveForm .
     ?presPassiveForm ontolex:representation ?presPassive ;
@@ -76,6 +83,7 @@ WHERE {
   }
 
   # MARK: Preterite Passive
+
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pretPassiveForm .
     ?pretPassiveForm ontolex:representation ?pretPassive ;

--- a/src/scribe_data/language_data_extraction/Danish/verbs/query_verbs.sparql
+++ b/src/scribe_data/language_data_extraction/Danish/verbs/query_verbs.sparql
@@ -5,14 +5,90 @@
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?infinitive
+  ?infActive
+  ?presActive
+  ?pretActive
+  ?pastPart
+  ?presPart
+  ?imperative
+  ?presPassive
+  ?pretPassive
+  ?infPassive
+
 
 WHERE {
+  # Infinitive
   ?lexeme dct:language wd:Q9035 ;
-    wikibase:lexicalCategory wd:Q24905 .
+    wikibase:lexicalCategory wd:Q24905 ;
+    wikibase:lemma ?infinitive
 
-  # MARK: Infinitive
+  # MARK: Infinitive Active
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?infActiveForm .
+    ?infActiveForm ontolex:representation ?infActive ;
+      wikibase:grammaticalFeature wd:Q179230 ;
+      wikibase:grammaticalFeature wd:Q1317831 .
+  }
 
-  ?lexeme ontolex:lexicalForm ?infinitiveForm .
-  ?infinitiveForm ontolex:representation ?infinitive ;
-    wikibase:grammaticalFeature wd:Q179230 ;
+  # MARK: Present Tense Active
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?presActiveForm .
+    ?presActiveForm ontolex:representation ?presActive ;
+      wikibase:grammaticalFeature wd:Q192613 ;
+      wikibase:grammaticalFeature wd:Q1317831 .
+  }
+
+  # MARK: Preterite Active
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?pretActiveForm .
+    ?pretActiveForm ontolex:representation ?pretActive ;
+      wikibase:grammaticalFeature wd:Q442485 ;
+      wikibase:grammaticalFeature wd:Q1317831 .
+  }
+
+  # MARK: Past Participle
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?pastPartForm .
+    ?pastPartForm ontolex:representation ?pastPart ;
+      wikibase:grammaticalFeature wd:Q12717679 .
+  }
+
+  # MARK: Present Participle
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?presPartForm .
+    ?presPartForm ontolex:representation ?presPart ;
+      wikibase:grammaticalFeature wd:Q10345583 .
+  }
+
+  # MARK: Imperative
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?imperativeForm .
+    ?imperativeForm ontolex:representation ?imperative ;
+      wikibase:grammaticalFeature wd:Q22716 .
+  }
+
+  # MARK: Present Passive
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?presPassiveForm .
+    ?presPassiveForm ontolex:representation ?presPassive ;
+      wikibase:grammaticalFeature wd:Q442485 ;
+      wikibase:grammaticalFeature wd:Q1194697 .
+  }
+
+  # MARK: Preterite Passive
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?pretPassiveForm .
+    ?pretPassiveForm ontolex:representation ?pretPassive ;
+      wikibase:grammaticalFeature wd:Q442485 ;
+      wikibase:grammaticalFeature wd:Q1194697 .
+  }
+
+  # MARK: Infinitive Passive
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?infPassiveForm .
+    ?infPassiveForm ontolex:representation ?infPassive ;
+      wikibase:grammaticalFeature wd:Q179230 ;
+      wikibase:grammaticalFeature wd:Q1194697 .
+  }
 }


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
This pull request expands the Danish verb query in [src/scribe_data/language_data_extraction/Danish/verbs/query_verbs.sparql](https://github.com/scribe-org/Scribe-Data/blob/main/src/scribe_data/language_data_extraction/Danish/verbs/query_verbs.sparql) by adding more conjugation forms available on Wikidata.

The forms included in this update are:

- Infinitive: The base form of the verb.
- Infinitive Active: The active form of the infinitive.
- Present Tense Active: Verb form indicating an action currently happening.
- Preterite Active: Simple past tense form for completed actions.
- Past Participle: Used in perfect tenses or as an adjective.
- Present Participle: Non-finite form used for continuous tenses or as an adjective.
- Imperative: Verb form used for commands.
- Present Passive: Present tense form indicating passive action.
- Preterite Passive: Passive form of the past tense.
- Infinitive Passive: Passive form of the infinitive.

The query has been tested and runs correctly on the [Wikidata Query Service](https://query.wikidata.org/)

### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #225
