### PR TITLE
Add SPARQL query to retrieve all English adjectives

### DIFF
--- a/src/scribe_data/language_data_extraction/English/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/language_data_extraction/English/adjectives/query_adjectives.sparql
@@ -1,0 +1,18 @@
+# tool: scribe-data
+# All English (Q1860) adjectives.
+# Enter this query at https://query.wikidata.org/.
+
+SELECT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
+  ?adjective
+
+WHERE {
+  ?lexeme dct:language wd:Q1860 ;
+    wikibase:lexicalCategory wd:Q34698 ;
+    wikibase:lemma ?lemma .
+
+  SERVICE wikibase:label {
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE]".
+    ?lemma rdfs:label ?adjective .
+  }
+}


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

Integrated a SPARQL query to retrieve all adjectives in English (Q1860) from Wikidata. It targets English lexemes that fall under the lexical category of "adjectives" (Q34698). The query is intended for use with Scribe-Data and has been executed on the Wikidata Query Service.







### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #257 
