### PR TITLE
Create query_adverbs.sparql to incorporate the urdu adverbs

### DIFF
--- a/src/scribe_data/language_data_extraction/Urdu/adverbs/query_adverbs.sparql
+++ b/src/scribe_data/language_data_extraction/Urdu/adverbs/query_adverbs.sparql
@@ -1,0 +1,21 @@
+# tool: scribe-data
+# All Urdu (from Hindustani Q11051) adverbs.
+# Enter this query at https://query.wikidata.org/.
+# Note the necessity to filter for "ur" to remove Hindi (hi) words.
+
+SELECT DISTINCT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
+  ?adverb
+
+WHERE {
+  ?lexeme dct:language wd:Q11051 ;  # Urdu language (from Hindustani)
+    wikibase:lexicalCategory wd:Q380057 ;  # Adverbs
+    wikibase:lemma ?adverb .
+
+  BIND(lang(?adverb) as ?langAdverb)
+  FILTER(?langAdverb = "ur")
+
+  SERVICE wikibase:label {
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE]".
+  }
+}

--- a/src/scribe_data/language_data_extraction/Urdu/adverbs/query_adverbs.sparql
+++ b/src/scribe_data/language_data_extraction/Urdu/adverbs/query_adverbs.sparql
@@ -14,8 +14,4 @@ WHERE {
 
   BIND(lang(?adverb) as ?langAdverb)
   FILTER(?langAdverb = "ur")
-
-  SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE]".
-  }
 }


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This PR introduces a SPARQL query to extract all Urdu adverbs from Wikidata. The query targets Urdu lexemes under the lexical category of adverbs and retrieves their lemma forms while filtering out non-Urdu entries (e.g., Hindi).

Key Changes:
1. Added a new SPARQL query for extracting Urdu adverbs.
2. Filtered the results by language tag "ur" to ensure only Urdu lexemes are included (Hindi lexemes are added in the commit on this [PR](https://github.com/scribe-org/Scribe-Data/pull/240)). 
3. The query can be run on the Wikidata Query Service to retrieve a list of Urdu adverbs in their lemma form.
Usage:
The query can be used at `https://query.wikidata.org/` to fetch all Urdu adverbs along with their corresponding lexeme IDs.

Purpose:
This addition is meant to enhance the Urdu language dataset by providing easy access to adverbs in Urdu, which could support linguistic research and other language-related applications.

### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #238 
- #242
