### PR TITLE
Expanded Esperanto `query_verbs.sparql` with Tenses and Cases and Created adjective Query

### DIFF
--- a/src/scribe_data/language_data_extraction/Esperanto/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/language_data_extraction/Esperanto/adjectives/query_adjectives.sparql
@@ -1,0 +1,17 @@
+# tool: scribe-data
+# All Esperanto (Q143) adjectives.
+# Enter this query at https://query.wikidata.org/.
+
+SELECT DISTINCT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
+  ?adjective
+
+WHERE {
+  # Select lexemes in Esperanto that are adjectives
+  ?lexeme dct:language wd:Q143 ;
+    wikibase:lexicalCategory wd:Q34698 ; # Adjective category
+    wikibase:lemma ?adjective .
+
+  # Ensure we get only the lexeme forms that are adjectives in Esperanto
+  FILTER(LANG(?adjective) = "eo") .
+}

--- a/src/scribe_data/language_data_extraction/Esperanto/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/language_data_extraction/Esperanto/adjectives/query_adjectives.sparql
@@ -8,8 +8,8 @@ SELECT DISTINCT
 
 WHERE {
   # Select lexemes in Esperanto that are adjectives
-  ?lexeme dct:language wd:Q143 ;
-    wikibase:lexicalCategory wd:Q34698 ; # Adjective category
+  ?lexeme dct:language wd:Q143 ;  # Esperanto
+    wikibase:lexicalCategory wd:Q34698 ;  # Adjective
     wikibase:lemma ?adjective .
 
   # Ensure we get only the lexeme forms that are adjectives in Esperanto

--- a/src/scribe_data/language_data_extraction/Esperanto/verbs/query_verbs.sparql
+++ b/src/scribe_data/language_data_extraction/Esperanto/verbs/query_verbs.sparql
@@ -1,13 +1,79 @@
 # tool: scribe-data
-# All Esperanto (Q143) verbs.
+# All Esperanto (Q143) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
-  ?verb
+  ?infinitive
+  ?present
+  ?past
+  ?future
+  ?indicative
+  ?conditional
+  ?volitive
 
 WHERE {
+  # MARK: Infinitive
+
   ?lexeme dct:language wd:Q143 ;
     wikibase:lexicalCategory wd:Q24905 ;
-    wikibase:lemma ?verb .
+    wikibase:lemma ?infinitive .
+
+  # MARK: Present Tense
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?presentForm .
+    ?presentForm ontolex:representation ?present ;
+    wikibase:grammaticalFeature wd:Q192613 ; # Present tense in Esperanto
+    FILTER(LANG(?present) = "eo") .
+  } .
+
+  # MARK: Past Tense
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?pastForm .
+    ?pastForm ontolex:representation ?past ;
+    wikibase:grammaticalFeature wd:Q1994301 ; # Past tense in Esperanto
+    FILTER(LANG(?past) = "eo") .
+  } .
+
+  # MARK: Future Tense
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?futureForm .
+    ?futureForm ontolex:representation ?future ;
+    wikibase:grammaticalFeature wd:Q501405 ; # Future tense in Esperanto
+    FILTER(LANG(?future) = "eo") .
+  } .
+
+  # MARK: Indicative
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?indicativeForm .
+    ?indicativeForm ontolex:representation ?indicative ;
+    wikibase:grammaticalFeature wd:Q682111 ; # Indicative mood in Esperanto
+    FILTER(LANG(?indicative) = "eo") .
+  } .
+
+  # MARK: Conditional
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?conditionalForm .
+    ?conditionalForm ontolex:representation ?conditional ;
+    wikibase:grammaticalFeature wd:Q625581 ; # Conditional mood in Esperanto
+    FILTER(LANG(?conditional) = "eo") .
+  } .
+
+  # MARK: Volitive
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?volitiveForm .
+    ?volitiveForm ontolex:representation ?volitive ;
+    wikibase:grammaticalFeature wd:Q2532941 ; # Volitive mood in Esperanto
+    FILTER(LANG(?volitive) = "eo") .
+  } .
+
+  SERVICE wikibase:label {
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE]".
+  }
 }

--- a/src/scribe_data/language_data_extraction/Esperanto/verbs/query_verbs.sparql
+++ b/src/scribe_data/language_data_extraction/Esperanto/verbs/query_verbs.sparql
@@ -5,10 +5,9 @@
 SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?infinitive
-  ?present
-  ?past
-  ?future
-  ?indicative
+  ?presIndicative
+  ?pastIndicative
+  ?futIndicative
   ?conditional
   ?volitive
 
@@ -22,37 +21,31 @@ WHERE {
   # MARK: Present Tense
 
   OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?presentForm .
-    ?presentForm ontolex:representation ?present ;
-    wikibase:grammaticalFeature wd:Q192613 ; # Present tense in Esperanto
-    FILTER(LANG(?present) = "eo") .
+    ?lexeme ontolex:lexicalForm ?presIndicativeForm .
+    ?presIndicativeForm ontolex:representation ?presIndicative ;
+    wikibase:grammaticalFeature wd:Q192613 ;
+    wikibase:grammaticalFeature wd:Q682111 ;
+    FILTER(LANG(?presIndicative) = "eo") .
   } .
 
   # MARK: Past Tense
 
   OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?pastForm .
-    ?pastForm ontolex:representation ?past ;
-    wikibase:grammaticalFeature wd:Q1994301 ; # Past tense in Esperanto
-    FILTER(LANG(?past) = "eo") .
+    ?lexeme ontolex:lexicalForm ?pastIndicativeForm .
+    ?pastIndicativeForm ontolex:representation ?pastIndicative ;
+    wikibase:grammaticalFeature wd:Q1994301 ;
+    wikibase:grammaticalFeature wd:Q682111 ;
+    FILTER(LANG(?pastIndicative) = "eo") .
   } .
 
   # MARK: Future Tense
 
   OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?futureForm .
-    ?futureForm ontolex:representation ?future ;
-    wikibase:grammaticalFeature wd:Q501405 ; # Future tense in Esperanto
-    FILTER(LANG(?future) = "eo") .
-  } .
-
-  # MARK: Indicative
-
-  OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?indicativeForm .
-    ?indicativeForm ontolex:representation ?indicative ;
-    wikibase:grammaticalFeature wd:Q682111 ; # Indicative mood in Esperanto
-    FILTER(LANG(?indicative) = "eo") .
+    ?lexeme ontolex:lexicalForm ?futIndicativeForm .
+    ?futIndicativeForm ontolex:representation ?futIndicative ;
+    wikibase:grammaticalFeature wd:Q501405 ;
+    wikibase:grammaticalFeature wd:Q682111 ;
+    FILTER(LANG(?futIndicative) = "eo") .
   } .
 
   # MARK: Conditional
@@ -60,7 +53,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?conditionalForm .
     ?conditionalForm ontolex:representation ?conditional ;
-    wikibase:grammaticalFeature wd:Q625581 ; # Conditional mood in Esperanto
+    wikibase:grammaticalFeature wd:Q625581 ;
     FILTER(LANG(?conditional) = "eo") .
   } .
 
@@ -69,11 +62,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?volitiveForm .
     ?volitiveForm ontolex:representation ?volitive ;
-    wikibase:grammaticalFeature wd:Q2532941 ; # Volitive mood in Esperanto
+    wikibase:grammaticalFeature wd:Q2532941 ;
     FILTER(LANG(?volitive) = "eo") .
   } .
-
-  SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE]".
-  }
 }


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This pull request enhances the existing SPARQL query for Esperanto verbs by adding new tenses and moods to improve the extraction of verb conjugations from Wikidata. The updated query now includes the indicative, conditional, and volitive moods, in addition to present, past, and future tenses. This will allow us to retrieve a more comprehensive set of conjugations for Esperanto verbs, aligning with the structure used for other languages like English. 

Another file has been created containing the SPARQL query to extract the adjectives in the language from wikidata

1. Added indicative, conditional, and volitive moods to the query.
2. Retained support for present, past, and future tenses.
3. Optimized the query for use in the Wikidata Query Service to ensure smooth integration with Scribe-Data’s verb extraction module.
4. Creating adjective query.

The inclusion of these moods is essential for expanding Scribe-Data’s language coverage for Esperanto, as these forms are commonly used in both written and spoken contexts. This will help in building more complete linguistic datasets for the language.

Both the queries has been tested successfully on the Wikidata Query Service to ensure it retrieves the correct conjugations for Esperanto verbs.

### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #226
