### PR TITLE
Expanded Malayalam verbs to include other forms on Wikidata

### DIFF
--- a/src/scribe_data/language_data_extraction/Malayalam/verbs/query_verbs.sparql
+++ b/src/scribe_data/language_data_extraction/Malayalam/verbs/query_verbs.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Malayalam (Q36236) verbs.
+# All Malayalam (Q36236) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT DISTINCT
@@ -50,8 +50,4 @@ WHERE {
       wikibase:grammaticalFeature wd:Q1475560 ;
       FILTER(LANG(?simpleFuture) = "ml") .
   } .
-
-  SERVICE wikibase:label {
-    bd:serviceParam wikibase:language "[AUTO_LANGUAGE]".
-  }
 }

--- a/src/scribe_data/language_data_extraction/Malayalam/verbs/query_verbs.sparql
+++ b/src/scribe_data/language_data_extraction/Malayalam/verbs/query_verbs.sparql
@@ -2,12 +2,56 @@
 # All Malayalam (Q36236) verbs.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT
+SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?verb
+  ?presentInfinitive
+  ?simplePresent
+  ?simplePast
+  ?simpleFuture
 
 WHERE {
   ?lexeme dct:language wd:Q36236 ;
     wikibase:lexicalCategory wd:Q24905 ;
     wikibase:lemma ?verb .
+
+  # MARK: Present Infinitive
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?presentInfForm .
+    ?presentInfForm ontolex:representation ?presentInfinitive ;
+      wikibase:grammaticalFeature wd:Q52434245 ;
+      FILTER(LANG(?presentInfinitive) = "ml") .
+  } .
+
+  # MARK: Simple Present
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?simplePresentForm .
+    ?simplePresentForm ontolex:representation ?simplePresent ;
+      wikibase:grammaticalFeature wd:Q3910936 ;
+      FILTER(LANG(?simplePresent) = "ml") .
+  } .
+
+  # MARK: Simple Past
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?simplePastForm .
+    ?simplePastForm ontolex:representation ?simplePast ;
+      wikibase:grammaticalFeature wd:Q1392475 ;
+      FILTER(LANG(?simplePast) = "ml") .
+  } .
+
+  # MARK: Simple Future
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?simpleFutureForm .
+    ?simpleFutureForm ontolex:representation ?simpleFuture ;
+      wikibase:grammaticalFeature wd:Q1475560 ;
+      FILTER(LANG(?simpleFuture) = "ml") .
+  } .
+
+  SERVICE wikibase:label {
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE]".
+  }
 }


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
This pull request expands the Malayalam verbs query to include additional forms available on Wikidata, specifically:
- Present infinitive
- Simple present
- Simple past
- Simple future
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.
I modified the original query to fetch these forms, following the approach used for English verb queries. The update ensures that the query captures more verb conjugations for Malayalam verbs in the Wikidata .
Also, please describe shortly how you tested that your change actually works.
-->
The updated query was tested on the [Wikidata Query Service UI](https://query.wikidata.org/), and the expected forms were successfully retrieved.
### Related issue
[Expand Malayalam verbs query #231](https://github.com/scribe-org/Scribe-Data/issues/231)
<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #ISSUE_NUMBER
