### PR TITLE
Swahili adjectives querry

### DIFF
--- a/src/scribe_data/language_data_extraction/Swahili/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/language_data_extraction/Swahili/adjectives/query_adjectives.sparql
@@ -1,17 +1,15 @@
-SELECT DISTINCT
+# tool: scribe-data
+# All Swahili (Q7838) adjectives.
+# Enter this query at https://query.wikidata.org/.
+
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
-  ?lemma
-  ?adjectiveForm
+  ?adjective
 
 WHERE {
 
   ?lexeme dct:language wd:Q7838 ;
-          wikibase:lexicalCategory wd:Q34698 ;
-          wikibase:lemma ?lemma .
-
-
-  OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?adjectiveLexicalForm .
-    ?adjectiveLexicalForm ontolex:representation ?adjectiveForm .
-  } .
+    wikibase:lexicalCategory wd:Q34698 ;
+    wikibase:lemma ?adjective .
+    FILTER(lang(?adjective) = "sw")
 }

--- a/src/scribe_data/language_data_extraction/Swahili/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/language_data_extraction/Swahili/adjectives/query_adjectives.sparql
@@ -1,0 +1,17 @@
+SELECT DISTINCT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
+  ?lemma
+  ?adjectiveForm
+
+WHERE {
+  # Retrieve Swahili lexemes
+  ?lexeme dct:language wd:Q7838 ;  # Q7838 refers to Swahili
+          wikibase:lexicalCategory wd:Q34698 ;  # Q34698 refers to adjectives
+          wikibase:lemma ?lemma .
+
+  # Optional block to retrieve adjective form
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?adjectiveLexicalForm .
+    ?adjectiveLexicalForm ontolex:representation ?adjectiveForm .
+  } .
+}

--- a/src/scribe_data/language_data_extraction/Swahili/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/language_data_extraction/Swahili/adjectives/query_adjectives.sparql
@@ -5,11 +5,11 @@ SELECT DISTINCT
 
 WHERE {
   # Retrieve Swahili lexemes
-  ?lexeme dct:language wd:Q7838 ;  # Q7838 refers to Swahili
-          wikibase:lexicalCategory wd:Q34698 ;  # Q34698 refers to adjectives
+  ?lexeme dct:language wd:Q7838 ;
+          wikibase:lexicalCategory wd:Q34698 ;
           wikibase:lemma ?lemma .
 
-  # Optional block to retrieve adjective form
+
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?adjectiveLexicalForm .
     ?adjectiveLexicalForm ontolex:representation ?adjectiveForm .


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

Description: This pull request introduces a new SPARQL query that retrieves adjectives in the Swahili language. The query is designed to extract adjectives from Wikidata.

Changes Made:
Created a new SPARQL query file: query_adjectives.sparql located in src/scribe_data/language_data_extraction/Swahili/adjectives/.
The query selects distinct adjectives associated with their respective lexemes in the Swahili language.

Testing: I have tested the code on [Wikidata Query Service](https://query.wikidata.org/) to ensure its correctness and functionality.
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #254 
