### PR TITLE
adding query_verbs.sparql for kurmanji

### DIFF
--- a/src/scribe_data/language_data_extraction/Kurmanji/verbs/query_verbs.sparql
+++ b/src/scribe_data/language_data_extraction/Kurmanji/verbs/query_verbs.sparql
@@ -1,70 +1,14 @@
 # tool: scribe-data
-# All Kurmanji (Q36163) verbs.
+# All Kurmanji (Q36163) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?verb
-  ?form
-  ?grammaticalFeature
-  ?infinitive
-  ?directCase
-  ?gerund
-  ?intransitivePhase
-  ?basicPhase
-  ?conjParticiple
-  ?adverbial
-  ?absConstruction
-  ?accusative
-  ?ergative
-  ?additivePhase
 
 WHERE {
   ?lexeme dct:language wd:Q36163 ;
     wikibase:lexicalCategory wd:Q24905 ;
     wikibase:lemma ?verb .
-
-  
-  # Infinitive (basic form of the verb)
-  FILTER(lang(?verb) = "ku") .
-
-    # Forms associated with the grammatical features (direct case, gerund, etc.)
-  OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?formNode .
-    ?formNode ontolex:representation ?form ;
-             wikibase:grammaticalFeature ?grammaticalFeature .
-    FILTER(LANG(?form) = "ku") .
-  }
-  
-  OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?adverbialForm .
-    ?adverbialForm ontolex:representation ?adverbial ;
-    wikibase:grammaticalFeature wd:Q380012 .
-    FILTER(LANG(?adverbial) = "ku") .
-  } .
-
-  # MARK: Absolute Construction
-  OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?absConstructionForm .
-    ?absConstructionForm ontolex:representation ?absConstruction ;
-    wikibase:grammaticalFeature wd:Q4669807 .
-    FILTER(LANG(?absConstruction) = "ku") .
-  } .
-
-  # MARK: Accusative
-  OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?accusativeForm .
-    ?accusativeForm ontolex:representation ?accusative ;
-    wikibase:grammaticalFeature wd:Q1233197 .
-    FILTER(LANG(?accusative) = "ku") .
-  } .
-
-  # MARK: Ergative
-  OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?ergativeForm .
-    ?ergativeForm ontolex:representation ?ergative ;
-    wikibase:grammaticalFeature wd:Q1233197 .
-    FILTER(LANG(?ergative) = "ku") .
-  } .
-  
+    FILTER(lang(?verb) = "ku") .
 }

--- a/src/scribe_data/language_data_extraction/Kurmanji/verbs/query_verbs.sparql
+++ b/src/scribe_data/language_data_extraction/Kurmanji/verbs/query_verbs.sparql
@@ -69,6 +69,7 @@ WHERE {
     wikibase:grammaticalFeature wd:Q1233197 .
     FILTER(LANG(?ergative) = "ku") .
   } .
+  
 }
 
 

--- a/src/scribe_data/language_data_extraction/Kurmanji/verbs/query_verbs.sparql
+++ b/src/scribe_data/language_data_extraction/Kurmanji/verbs/query_verbs.sparql
@@ -25,7 +25,7 @@ WHERE {
     wikibase:lemma ?verb .
 
   
-     # Infinitive (basic form of the verb)
+  # Infinitive (basic form of the verb)
   FILTER(lang(?verb) = "ku") .
 
     # Forms associated with the grammatical features (direct case, gerund, etc.)
@@ -44,7 +44,6 @@ WHERE {
   } .
 
   # MARK: Absolute Construction
-
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?absConstructionForm .
     ?absConstructionForm ontolex:representation ?absConstruction ;
@@ -53,7 +52,6 @@ WHERE {
   } .
 
   # MARK: Accusative
-
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeForm .
     ?accusativeForm ontolex:representation ?accusative ;
@@ -62,7 +60,6 @@ WHERE {
   } .
 
   # MARK: Ergative
-
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?ergativeForm .
     ?ergativeForm ontolex:representation ?ergative ;
@@ -71,5 +68,3 @@ WHERE {
   } .
   
 }
-
-

--- a/src/scribe_data/language_data_extraction/Kurmanji/verbs/query_verbs.sparql
+++ b/src/scribe_data/language_data_extraction/Kurmanji/verbs/query_verbs.sparql
@@ -5,9 +5,78 @@
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?verb
+  ?form
+  ?grammaticalFeature
+  ?infinitive
+  ?directCase
+  ?gerund
+  ?intransitivePhase
+  ?basicPhase
+  ?conjParticiple
+  ?adverbial
+  ?absConstruction
+  ?accusative
+  ?ergative
+  ?additivePhase
 
 WHERE {
   ?lexeme dct:language wd:Q36163 ;
     wikibase:lexicalCategory wd:Q24905 ;
     wikibase:lemma ?verb .
+
+  
+     # Infinitive (basic form of the verb)
+  FILTER(lang(?verb) = "ku") .
+
+    # Forms associated with the grammatical features (direct case, gerund, etc.)
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?formNode .
+    ?formNode ontolex:representation ?form ;
+             wikibase:grammaticalFeature ?grammaticalFeature .
+    FILTER(LANG(?form) = "ku") .
+  }
+  
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?adverbialForm .
+    ?adverbialForm ontolex:representation ?adverbial ;
+    wikibase:grammaticalFeature wd:Q380012 .
+    FILTER(LANG(?adverbial) = "ku") .
+  } .
+
+  # MARK: Absolute Construction
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?absConstructionForm .
+    ?absConstructionForm ontolex:representation ?absConstruction ;
+    wikibase:grammaticalFeature wd:Q4669807 .
+    FILTER(LANG(?absConstruction) = "ku") .
+  } .
+
+  # MARK: Accusative
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?accusativeForm .
+    ?accusativeForm ontolex:representation ?accusative ;
+    wikibase:grammaticalFeature wd:Q1233197 .
+    FILTER(LANG(?accusative) = "ku") .
+  } .
+
+  # MARK: Ergative
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?ergativeForm .
+    ?ergativeForm ontolex:representation ?ergative ;
+    wikibase:grammaticalFeature wd:Q1233197 .
+    FILTER(LANG(?ergative) = "ku") .
+  } .
+  
+  
+  
+  
+
 }
+
+ORDER BY ASC (?lexemeID)
+
+
+

--- a/src/scribe_data/language_data_extraction/Kurmanji/verbs/query_verbs.sparql
+++ b/src/scribe_data/language_data_extraction/Kurmanji/verbs/query_verbs.sparql
@@ -69,14 +69,6 @@ WHERE {
     wikibase:grammaticalFeature wd:Q1233197 .
     FILTER(LANG(?ergative) = "ku") .
   } .
-  
-  
-  
-  
-
 }
-
-ORDER BY ASC (?lexemeID)
-
 
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch


### Description

- The query has been executed & tested on wikidata editor 
- Developed a SPARQL query to retrieve all Kurmanji (Q36163) verbs and their grammatical forms from Wikidata.
- Extracts lexeme IDs, verb forms, and various grammatical features including infinitive, gerund, accusative, and ergative.
- optional clauses to include additional forms such as adverbial, absolute construction, and participle

Issue reference
- #229 

@andrewtavis 


