### PR TITLE
Dynamic PYTHONPATH and Cross-Platform Script Execution

### DIFF
--- a/src/scribe_data/wikidata/query_data.py
+++ b/src/scribe_data/wikidata/query_data.py
@@ -22,10 +22,10 @@ Updates data for Scribe by running all or desired WDQS queries and formatting sc
 
 import json
 import os
+import subprocess
+import sys
 from pathlib import Path
 from urllib.error import HTTPError
-import sys
-import subprocess
 
 from tqdm.auto import tqdm
 
@@ -33,6 +33,52 @@ from scribe_data.cli.cli_utils import (
     language_metadata,
 )
 from scribe_data.wikidata.wikidata_utils import sparql
+
+
+def execute_formatting_script(formatting_file_path, output_dir):
+    """
+    Executes a formatting script given a filepath and output directory for the process.
+
+    Parameters
+    ----------
+        formatting_file_path : str
+            The formatting file to run.
+
+        output_dir : str
+            The output directory path for results.
+
+    Returns
+    -------
+        The results of the formatting script saved in the given output directory.
+    """
+    # Determine the root directory of the project.
+    project_root = Path(__file__).parent.parent
+
+    if sys.platform.startswith("win"):
+        python_executable = sys.executable
+        pythonpath = str(project_root)
+
+        # Create environment with updated PYTHONPATH.
+        env = os.environ.copy()
+        if "PYTHONPATH" in env:
+            env["PYTHONPATH"] = f"{pythonpath};{env['PYTHONPATH']}"
+
+        else:
+            env["PYTHONPATH"] = pythonpath
+
+        # Use subprocess.run instead of os.system.
+        subprocess.run(
+            [python_executable, str(formatting_file_path), "--file-path", output_dir],
+            env=env,
+            check=True,
+        )
+
+    else:
+        # Unix-like systems (Linux, macOS).
+        subprocess.run(
+            ["python3", str(formatting_file_path), "--file-path", output_dir],
+            check=True,
+        )
 
 
 def query_data(
@@ -264,39 +310,9 @@ def query_data(
                 / target_type
                 / f"format_{target_type}.py"
             )
-            # Replace the original os.system call with:
-            execute_formatting_script(formatting_file_path, output_dir)
-
-            # os.system(f"python3 {formatting_file_path} --file-path {output_dir}")
-
-
-def execute_formatting_script(formatting_file_path, output_dir):
-    # Determine the root directory of the project
-    project_root = Path(__file__).parent.parent
-
-    if sys.platform.startswith("win"):
-        python_executable = sys.executable
-        pythonpath = str(project_root)
-
-        # Create environment with updated PYTHONPATH
-        env = os.environ.copy()
-        if "PYTHONPATH" in env:
-            env["PYTHONPATH"] = f"{pythonpath};{env['PYTHONPATH']}"
-        else:
-            env["PYTHONPATH"] = pythonpath
-
-        # Use subprocess.run instead of os.system
-        subprocess.run(
-            [python_executable, str(formatting_file_path), "--file-path", output_dir],
-            env=env,
-            check=True,
-        )
-    else:
-        # Unix-like systems (Linux, macOS)
-        subprocess.run(
-            ["python3", str(formatting_file_path), "--file-path", output_dir],
-            check=True,
-        )
+            execute_formatting_script(
+                formatting_file_path=formatting_file_path, output_dir=output_dir
+            )
 
 
 if __name__ == "__main__":

--- a/src/scribe_data/wikidata/query_data.py
+++ b/src/scribe_data/wikidata/query_data.py
@@ -24,6 +24,8 @@ import json
 import os
 from pathlib import Path
 from urllib.error import HTTPError
+import sys
+import subprocess
 
 from tqdm.auto import tqdm
 
@@ -262,7 +264,39 @@ def query_data(
                 / target_type
                 / f"format_{target_type}.py"
             )
-            os.system(f"python3 {formatting_file_path} --file-path {output_dir}")
+            # Replace the original os.system call with:
+            execute_formatting_script(formatting_file_path, output_dir)
+
+            # os.system(f"python3 {formatting_file_path} --file-path {output_dir}")
+
+
+def execute_formatting_script(formatting_file_path, output_dir):
+    # Determine the root directory of the project
+    project_root = Path(__file__).parent.parent
+
+    if sys.platform.startswith("win"):
+        python_executable = sys.executable
+        pythonpath = str(project_root)
+
+        # Create environment with updated PYTHONPATH
+        env = os.environ.copy()
+        if "PYTHONPATH" in env:
+            env["PYTHONPATH"] = f"{pythonpath};{env['PYTHONPATH']}"
+        else:
+            env["PYTHONPATH"] = pythonpath
+
+        # Use subprocess.run instead of os.system
+        subprocess.run(
+            [python_executable, str(formatting_file_path), "--file-path", output_dir],
+            env=env,
+            check=True,
+        )
+    else:
+        # Unix-like systems (Linux, macOS)
+        subprocess.run(
+            ["python3", str(formatting_file_path), "--file-path", output_dir],
+            check=True,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description
If user give queries, windows likely to run [format_target_type.py](https://github.com/scribe-org/Scribe-Data/blob/f9e6f603db190e012dd956fc1b99944625482d54/src/scribe_data/language_data_extraction/English/nouns/format_nouns.py) without an environment. Here `execute_formatting_script` dynamically sets the `PYTHONPATH` and runs a formatting script using `subprocess.run` on either Windows or Unix-like systems

- [Calling OS' Python Executable](https://stackoverflow.com/questions/52356102/calling-os-python-executable-from-another-python-process)

 
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->


