### PR TITLE
Add SPARQL query for extracting Nigerian Pidgin nouns with gender and plurals

### DIFF
--- a/src/scribe_data/language_data_extraction/Pidgin/Nigerian/nouns/query_nouns.sparql
+++ b/src/scribe_data/language_data_extraction/Pidgin/Nigerian/nouns/query_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Nigerian Pidgin (Q33655) nouns and their gender.
+# All Nigerian Pidgin (Q33655) nouns, their plurals and their genders.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT DISTINCT
@@ -7,30 +7,31 @@ SELECT DISTINCT
   ?singular
   ?plural
   ?gender
-WHERE {
-  VALUES ?nounTypes {wd:Q1084} # Nouns
 
-  # Main noun data
+WHERE {
+  VALUES ?nounTypes {wd:Q1084 wd:Q147276} # Nouns and pronouns
+
   ?lexeme dct:language wd:Q33655 ; # Nigerian Pidgin
     wikibase:lexicalCategory ?nounTypes ;
     wikibase:lemma ?singular .
 
-  # Plural form (if exists)
+  # MARK: Plural
+
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pluralForm .
     ?pluralForm ontolex:representation ?plural ;
-      wikibase:grammaticalFeature wd:Q146786 ; # Plural
+      wikibase:grammaticalFeature wd:Q146786 ;
   } .
 
-  # Gender (if specified)
+  # MARK: Gender(s)
+
   OPTIONAL {
-    ?lexeme wdt:P5185 ?nounGender . # Grammatical gender
+    ?lexeme wdt:P5185 ?nounGender .
     FILTER NOT EXISTS {
       ?lexeme wdt:P31 wd:Q202444 .
     }
   } .
 
-  # Get readable gender labels
   SERVICE wikibase:label {
     bd:serviceParam wikibase:language "[AUTO_LANGUAGE]".
     ?nounGender rdfs:label ?gender .

--- a/src/scribe_data/language_data_extraction/Pidgin/Nigerian/nouns/query_nouns.sparql
+++ b/src/scribe_data/language_data_extraction/Pidgin/Nigerian/nouns/query_nouns.sparql
@@ -1,0 +1,38 @@
+# tool: scribe-data
+# All Nigerian Pidgin (Q33655) nouns and their gender.
+# Enter this query at https://query.wikidata.org/.
+
+SELECT DISTINCT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
+  ?singular
+  ?plural
+  ?gender
+WHERE {
+  VALUES ?nounTypes {wd:Q1084} # Nouns
+
+  # Main noun data
+  ?lexeme dct:language wd:Q33655 ; # Nigerian Pidgin
+    wikibase:lexicalCategory ?nounTypes ;
+    wikibase:lemma ?singular .
+
+  # Plural form (if exists)
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?pluralForm .
+    ?pluralForm ontolex:representation ?plural ;
+      wikibase:grammaticalFeature wd:Q146786 ; # Plural
+  } .
+
+  # Gender (if specified)
+  OPTIONAL {
+    ?lexeme wdt:P5185 ?nounGender . # Grammatical gender
+    FILTER NOT EXISTS {
+      ?lexeme wdt:P31 wd:Q202444 .
+    }
+  } .
+
+  # Get readable gender labels
+  SERVICE wikibase:label {
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE]".
+    ?nounGender rdfs:label ?gender .
+  }
+}


### PR DESCRIPTION
- Implemented a SPARQL query to extract nouns in Nigerian Pidgin (Q33655).
- Extracts the singular form, optional plural form, and optional grammatical gender.
- Ensures readable labels for gender using the Wikibase label service.
- Handles cases where a lexeme doesn't have a plural or specified gender.

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- fixes #220
