### PR TITLE
Expand Bokmål verbs query

### DIFF
--- a/src/scribe_data/language_data_extraction/Bokmål/verbs/query_verbs.sparql
+++ b/src/scribe_data/language_data_extraction/Bokmål/verbs/query_verbs.sparql
@@ -6,6 +6,8 @@
 SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?infinitive
+  ?present
+  ?past
 
 WHERE {
   ?lexeme dct:language wd:Q25167 ;
@@ -16,4 +18,17 @@ WHERE {
   ?lexeme ontolex:lexicalForm ?infinitiveForm .
   ?infinitiveForm ontolex:representation ?infinitive ;
     wikibase:grammaticalFeature wd:Q179230 ;
+
+    OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?presentForm .
+    ?presentForm ontolex:representation ?present ;
+                 wikibase:grammaticalFeature wd:Q10345583 .
+  }
+
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?pastForm .
+    ?pastForm ontolex:representation ?past ;
+              wikibase:grammaticalFeature wd:Q12717679 .
+  }
 }

--- a/src/scribe_data/language_data_extraction/Bokmål/verbs/query_verbs.sparql
+++ b/src/scribe_data/language_data_extraction/Bokmål/verbs/query_verbs.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Bokmål (Norwegian) (Q9043) verbs.
+# All Bokmål (Norwegian) (Q9043) and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
 # Note: This query is for Bokmål (Q25167) rather than Nynorsk (Q25164).
 
@@ -7,28 +7,24 @@ SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?infinitive
   ?present
-  ?past
 
 WHERE {
   ?lexeme dct:language wd:Q25167 ;
     wikibase:lexicalCategory wd:Q24905 .
 
-  # MARK: Infinitive
+  # MARK: Active Infinitive
 
   ?lexeme ontolex:lexicalForm ?infinitiveForm .
   ?infinitiveForm ontolex:representation ?infinitive ;
     wikibase:grammaticalFeature wd:Q179230 ;
+    wikibase:grammaticalFeature wd:Q1317831 .
 
-    OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?presentForm .
-    ?presentForm ontolex:representation ?present ;
-                 wikibase:grammaticalFeature wd:Q10345583 .
-  }
-
+  # MARK: Active Present
 
   OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?pastForm .
-    ?pastForm ontolex:representation ?past ;
-              wikibase:grammaticalFeature wd:Q12717679 .
+    ?lexeme ontolex:lexicalForm ?presentForm .
+    ?presentForm ontolex:representation ?present ;
+      wikibase:grammaticalFeature wd:Q192613 ;
+      wikibase:grammaticalFeature wd:Q1317831 .
   }
 }


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This pull request proposes to expand the Bokmål verb query in src/scribe_data/language_data_extraction/Bokmål/verbs/query_verbs.sparql by including additional conjugations for verbs, such as present and past tense. The query was updated to check which conjugations are available for Bokmål verbs in Wikidata and to capture those using optional selections for certain grammatical features.

Testing
The SPARQL query was tested on the Wikidata Query Service UI to ensure that it correctly retrieves verbs with present and past tense conjugations where available.
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #223 
