### PR TITLE
Update data_type_metadata.json to include more data types

### DIFF
--- a/src/scribe_data/resources/data_type_metadata.json
+++ b/src/scribe_data/resources/data_type_metadata.json
@@ -9,9 +9,9 @@
     "verbs": "Q24905",
     "adjectives": "Q34698",
     "adverbs": "Q380057",
-    "prepositions": "Q37649",
-    "postpositions": "Q4833830",
-    "conjunctions": "Q161873",
-    "articles": "Q191536"
+    "prepositions": "Q4833830",
+    "postpositions": "Q161873",
+    "conjunctions": "Q36484",
+    "articles": "Q103184"
   }
 }

--- a/src/scribe_data/resources/data_type_metadata.json
+++ b/src/scribe_data/resources/data_type_metadata.json
@@ -1,10 +1,17 @@
 {
   "data-types": {
-    "autosuggestions":"",
-    "emoji_keywords":"",
+    "autosuggestions": "",
+    "emoji_keywords": "",
     "nouns": "Q1084",
+    "proper_nouns": "Q147276",
+    "pronouns": "Q36224",
+    "personal_pronouns": "Q468801",
+    "verbs": "Q24905",
+    "adjectives": "Q34698",
+    "adverbs": "Q380057",
     "prepositions": "Q37649",
-    "translations": "Q7553789",
-    "verbs": "Q24905"
+    "postpositions": "Q4833830",
+    "conjunctions": "Q161873",
+    "articles": "Q191536"
   }
 }


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

The issue aims to add more data to the `data_type_metadata.json` to include adjectives, adverbs, prepositions etc to the pre-existing data types for all the languages. With this PR, the .JSON file now includes proper nouns, pronouns, personal pronouns, adjectives, adverbs, postpositions, conjunctions, and articles in addition to the existing categories.

### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #297
