### PR TITLE
Added adverbs and prepositions for japanese

### DIFF
--- a/src/scribe_data/language_data_extraction/Japanese/adverbs/query_adverbs.sparql
+++ b/src/scribe_data/language_data_extraction/Japanese/adverbs/query_adverbs.sparql
@@ -1,0 +1,15 @@
+# tool: scribe-data
+# All Japanese (Q5287) adverbs.
+# Enter this query at https://query.wikidata.org/.
+
+SELECT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
+  ?adverb
+
+WHERE {
+  ?lexeme dct:language wd:Q5287 ;
+    wikibase:lexicalCategory wd:Q380057 ;
+    wikibase:lemma ?adverb .
+
+   FILTER(lang(?adverb) = "ja-hira")
+}

--- a/src/scribe_data/language_data_extraction/Japanese/adverbs/query_adverbs.sparql
+++ b/src/scribe_data/language_data_extraction/Japanese/adverbs/query_adverbs.sparql
@@ -10,6 +10,5 @@ WHERE {
   ?lexeme dct:language wd:Q5287 ;
     wikibase:lexicalCategory wd:Q380057 ;
     wikibase:lemma ?adverb .
-
-   FILTER(lang(?adverb) = "ja-hira")
+    FILTER(lang(?adverb) = "ja-hira")
 }

--- a/src/scribe_data/language_data_extraction/Japanese/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/language_data_extraction/Japanese/prepositions/query_prepositions.sparql
@@ -1,0 +1,15 @@
+# tool: scribe-data
+# All Japanese (Q5287) adverbs.
+# Enter this query at https://query.wikidata.org/.
+
+SELECT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
+  ?preposition
+
+WHERE {
+  ?lexeme dct:language wd:Q5287 ;
+    wikibase:lexicalCategory wd:Q4833830 ;
+    wikibase:lemma ?preposition .
+
+   FILTER(lang(?preposition) = "ja-hira")
+}

--- a/src/scribe_data/language_data_extraction/Japanese/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/language_data_extraction/Japanese/prepositions/query_prepositions.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Japanese (Q5287) adverbs.
+# All Japanese (Q5287) prepositions.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT
@@ -10,6 +10,5 @@ WHERE {
   ?lexeme dct:language wd:Q5287 ;
     wikibase:lexicalCategory wd:Q4833830 ;
     wikibase:lemma ?preposition .
-
-   FILTER(lang(?preposition) = "ja-hira")
+    FILTER(lang(?preposition) = "ja-hira")
 }


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

Addition of Japanese Prepositions Query:
Created a new SPARQL query file under src/scribe_data/language_data_extraction/Japanese/prepositions/query_prepositions.sparql to fetch prepositions for Japanese, aligned with the structure used for other languages.

Addition of Japanese Adverbs Query:
Added a new SPARQL query file under src/scribe_data/language_data_extraction/Japanese/adverbs/query_adverbs.sparql to capture adverbs in Japanese, filtering by "ja-hira" (Japanese Hiragana script).

Testing:
I manually checked the queries by executing them to confirm that they return valid results from the dataset at query.wikidata.org
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #301 
