### PR TITLE
Add Japanese emoji keywords generation

### DIFF
--- a/src/scribe_data/language_data_extraction/Japanese/emoji_keywords/generate_emoji_keywords.py
+++ b/src/scribe_data/language_data_extraction/Japanese/emoji_keywords/generate_emoji_keywords.py
@@ -1,0 +1,46 @@
+"""
+Generates keyword-emoji relationships from a selection of English words.
+
+.. raw:: html
+    <!--
+    * Copyright (C) 2024 Scribe
+    *
+    * This program is free software: you can redistribute it and/or modify
+    * it under the terms of the GNU General Public License as published by
+    * the Free Software Foundation, either version 3 of the License, or
+    * (at your option) any later version.
+    *
+    * This program is distributed in the hope that it will be useful,
+    * but WITHOUT ANY WARRANTY; without even the implied warranty of
+    * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    * GNU General Public License for more details.
+    *
+    * You should have received a copy of the GNU General Public License
+    * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    -->
+"""
+
+import argparse
+
+from scribe_data.unicode.process_unicode import gen_emoji_lexicon
+from scribe_data.utils import export_formatted_data
+
+LANGUAGE = "japanese"
+DATA_TYPE = "emoji-keywords"
+emojis_per_keyword = 3
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--file-path")
+args = parser.parse_args()
+
+if emoji_keywords_dict := gen_emoji_lexicon(
+    language=LANGUAGE,
+    emojis_per_keyword=emojis_per_keyword,
+):
+    export_formatted_data(
+        file_path=args.file_path,
+        formatted_data=emoji_keywords_dict,
+        query_data_in_use=True,
+        language=LANGUAGE,
+        data_type=DATA_TYPE,
+    )

--- a/src/scribe_data/language_data_extraction/Japanese/emoji_keywords/generate_emoji_keywords.py
+++ b/src/scribe_data/language_data_extraction/Japanese/emoji_keywords/generate_emoji_keywords.py
@@ -1,5 +1,5 @@
 """
-Generates keyword-emoji relationships from a selection of English words.
+Generates keyword-emoji relationships from a selection of Japanese words.
 
 .. raw:: html
     <!--
@@ -25,7 +25,7 @@ import argparse
 from scribe_data.unicode.process_unicode import gen_emoji_lexicon
 from scribe_data.utils import export_formatted_data
 
-LANGUAGE = "japanese"
+LANGUAGE = "Japanese"
 DATA_TYPE = "emoji-keywords"
 emojis_per_keyword = 3
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This pull request introduces a feature to generate keyword-emoji relationships, the implementation allows for the extraction of emojis associated with specified Japanese keywords.
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #301 
