### PR TITLE
Added functionality to convert data to CSV/TSV and JSON and vice versa.

### DIFF
--- a/src/scribe_data/cli/convert.py
+++ b/src/scribe_data/cli/convert.py
@@ -30,6 +30,9 @@ from scribe_data.cli.cli_utils import language_map
 from scribe_data.load.data_to_sqlite import data_to_sqlite
 from scribe_data.utils import (
     DEFAULT_SQLITE_EXPORT_DIR,
+    DEFAULT_JSON_EXPORT_DIR,
+    DEFAULT_CSV_EXPORT_DIR,
+    DEFAULT_TSV_EXPORT_DIR,
     get_language_iso,
 )
 
@@ -41,8 +44,8 @@ def convert_to_json(
     data_type: Union[str, List[str]],
     output_type: str,
     input_file: str,
-    output_dir: str,
-    overwrite: bool,
+    output_dir: str = None,
+    overwrite: bool = False,
 ) -> None:
     """
     Convert a CSV/TSV file to JSON.
@@ -77,6 +80,9 @@ def convert_to_json(
         raise ValueError(f"Language '{language.capitalize()}' is not recognized.")
 
     data_types = [data_type] if isinstance(data_type, str) else data_type
+
+    if output_dir is None:
+        output_dir = DEFAULT_JSON_EXPORT_DIR
 
     json_output_dir = Path(output_dir) / normalized_language["language"].capitalize()
     json_output_dir.mkdir(parents=True, exist_ok=True)
@@ -175,8 +181,8 @@ def convert_to_csv_or_tsv(
     data_type: Union[str, List[str]],
     output_type: str,
     input_file: str,
-    output_dir: str,
-    overwrite: bool,
+    output_dir: str = None,
+    overwrite: bool = False,
 ) -> None:
     """
     Convert a JSON File to CSV/TSV file.
@@ -231,6 +237,13 @@ def convert_to_csv_or_tsv(
 
         # Determine the delimiter based on output type
         delimiter = "," if output_type == "csv" else "\t"
+
+        if output_dir is None:
+            output_dir = (
+                DEFAULT_CSV_EXPORT_DIR
+                if output_type == "csv"
+                else DEFAULT_TSV_EXPORT_DIR
+            )
 
         final_output_dir = (
             Path(output_dir) / normalized_language["language"].capitalize()
@@ -326,7 +339,7 @@ def convert_to_sqlite(
     data_type: str,
     output_type: str,
     input_file: str = None,
-    output_dir: str = DEFAULT_SQLITE_EXPORT_DIR,
+    output_dir: str = None,
     overwrite: bool = False,
 ) -> None:
     """

--- a/src/scribe_data/cli/convert.py
+++ b/src/scribe_data/cli/convert.py
@@ -24,32 +24,43 @@ import csv
 import json
 import shutil
 from pathlib import Path
+from typing import List, Union
 
 from scribe_data.cli.cli_utils import language_map
 from scribe_data.load.data_to_sqlite import data_to_sqlite
 from scribe_data.utils import (
-    DEFAULT_SQLITE_EXPORT_DIR,
     get_language_iso,
 )
 
 # MARK: JSON
 
 
-def export_json(
-    language: str, data_type: str, output_dir: Path, overwrite: bool
+def convert_to_json(
+    language: str,
+    data_type: Union[str, List[str]],
+    output_type: str,
+    input_file: str,
+    output_dir: str,
+    overwrite: bool,
 ) -> None:
     """
-    Export a JSON file from the CLI process.
+    Convert a CSV/TSV file to JSON.
 
     Parameters
     ----------
         language : str
             The language of the file to convert.
 
-        data_type : str
-            The data type to of the file to convert.
+        data_type : Union[str, List[str]]
+            The data type of the file to convert.
 
-        output_dir : str
+        output_type : str
+            The output format, should be "json".
+
+        input_file : str
+            The input CSV/TSV file path.
+
+        output_dir : Path
             The output directory path for results.
 
         overwrite : bool
@@ -57,121 +68,172 @@ def export_json(
 
     Returns
     -------
-        A JSON file saved in the given location.
+        None
     """
     normalized_language = language_map.get(language.lower())
 
     if not normalized_language:
         raise ValueError(f"Language '{language.capitalize()}' is not recognized.")
 
-    data_type = data_type[0] if isinstance(data_type, list) else data_type
-    data_file = (
-        output_dir / normalized_language["language"].capitalize() / f"{data_type}.json"
-    )
+    data_types = [data_type] if isinstance(data_type, str) else data_type
 
-    print(data_file)
-
-    if not data_file.exists():
-        print(
-            f"No data found for language '{normalized_language['language']}' and data type '{data_type}'."
-        )
-        return
-
-    try:
-        with data_file.open("r", encoding="utf-8") as file:
-            data = json.load(file)
-
-    except (IOError, json.JSONDecodeError) as e:
-        print(f"Error reading '{data_file}': {e}")
-        return
-
-    json_output_dir = output_dir / normalized_language["language"].capitalize()
+    json_output_dir = Path(output_dir) / normalized_language["language"].capitalize()
     json_output_dir.mkdir(parents=True, exist_ok=True)
 
-    output_file = json_output_dir / f"{data_type}.json"
-    if output_file.exists() and not overwrite:
-        user_input = input(f"File '{output_file}' already exists. Overwrite? (y/n): ")
-        if user_input.lower() != "y":
-            print(f"Skipping {normalized_language['language']} - {data_type}")
-            return
+    for dtype in data_types:
+        input_file_path = Path(input_file)
 
-    try:
-        with output_file.open("w") as file:
-            json.dump(data, file, indent=0)
+        if not input_file_path.exists():
+            print(f"No data found for input file '{input_file_path}'.")
+            continue
 
-    except IOError as e:
-        raise IOError(f"Error writing to '{output_file}': {e}") from e
+        delimiter = "," if input_file_path.suffix.lower() == ".csv" else "\t"
 
-    print(
-        f"Data for {normalized_language['language'].capitalize()} {data_type} written to {output_file}"
-    )
+        try:
+            with input_file_path.open("r", encoding="utf-8") as file:
+                reader = csv.DictReader(file, delimiter=delimiter)
+                rows = list(reader)
+
+                if not rows:
+                    print(f"No data found in '{input_file_path}'.")
+                    continue
+
+                # Use the first row to inspect column headers
+                first_row = rows[0]
+                keys = list(first_row.keys())
+                data = {}
+
+                if len(keys) == 1:
+                    # Handle Case: { key: None }
+                    data[first_row[keys[0]]] = None
+
+                elif len(keys) == 2:
+                    # Handle Case: { key: value }
+                    for row in rows:
+                        key = row[keys[0]]
+                        value = row[keys[1]]
+                        data[key] = value
+
+                elif len(keys) > 2:
+                    if all(col in first_row for col in ["emoji", "is_base", "rank"]):
+                        # Handle Case: { key: [ { emoji: ..., is_base: ..., rank: ... }, { emoji: ..., is_base: ..., rank: ... } ] }
+                        for row in rows:
+                            key = row.get(reader.fieldnames[0])
+                            emoji = row.get("emoji", "").strip()
+                            is_base = (
+                                row.get("is_base", "false").strip().lower() == "true"
+                            )
+                            rank = row.get("rank", None)
+                            rank = int(rank) if rank and rank.isdigit() else None
+
+                            entry = {"emoji": emoji, "is_base": is_base, "rank": rank}
+
+                            if key not in data:
+                                data[key] = []
+                            data[key].append(entry)
+
+                    else:
+                        # Handle Case: { key: { value1: ..., value2: ... } }
+                        for row in rows:
+                            data[row[keys[0]]] = {k: row[k] for k in keys[1:]}
+
+        except (IOError, csv.Error) as e:
+            print(f"Error reading '{input_file_path}': {e}")
+            continue
+
+        # Define output file path
+        output_file = json_output_dir / f"{dtype}.{output_type}"
+
+        if output_file.exists() and not overwrite:
+            user_input = input(
+                f"File '{output_file}' already exists. Overwrite? (y/n): "
+            )
+            if user_input.lower() != "y":
+                print(f"Skipping {normalized_language['language']} - {dtype}")
+                continue
+
+        try:
+            with output_file.open("w", encoding="utf-8") as file:
+                json.dump(data, file, ensure_ascii=False, indent=2)
+
+        except IOError as e:
+            print(f"Error writing to '{output_file}': {e}")
+            continue
+
+        print(
+            f"Data for {normalized_language['language'].capitalize()} {dtype} written to {output_file}"
+        )
 
 
+#
 # MARK: CSV or TSV
 
 
 def convert_to_csv_or_tsv(
     language: str,
-    data_type: list,
-    output_dir: Path,
-    overwrite: bool,
+    data_type: Union[str, List[str]],
     output_type: str,
+    input_file: str,
+    output_dir: str,
+    overwrite: bool,
 ) -> None:
     """
-    Converts a Scribe-Data output file to a CSV or TSV file.
+    Convert a JSON File to CSV/TSV file.
 
     Parameters
     ----------
-        output_type : str
-            The file type to convert to (CSV or TSV).
+    language : str
+        The language of the file to convert.
 
-        language : str
-            The language of the file to convert.
+    data_type : Union[str, List[str]]
+        The data type of the file to convert.
 
-        data_type : str
-            The data type to of the file to convert.
+    output_type : str
+        The output format, should be "csv" or "tsv".
 
-        output_dir : str
-            The output directory path for results.
+    input_file : str
+        The input JSON file path.
 
-        overwrite : bool
-            Whether to overwrite existing files.
+    output_dir : str
+        The output directory path for results.
+
+    overwrite : bool
+        Whether to overwrite existing files.
 
     Returns
     -------
-        A CSV or TSV file saved in the given location.
+        None
     """
+
+    # Normalize the language
     normalized_language = language_map.get(language.lower())
     if not normalized_language:
         print(f"Language '{language}' is not recognized.")
         return
 
-    for dtype in data_type:
-        # Replace non-JSON default paths with JSON path for where exported data is.
-        file_path = (
-            Path(
-                str(output_dir)
-                .replace("scribe_data_csv_export", "scribe_data_json_export")
-                .replace("scribe_data_tsv_export", "scribe_data_json_export")
-            )
-            / normalized_language["language"].capitalize()
-            / f"{dtype}.json"
-        )
-        if not file_path.exists():
-            raise FileNotFoundError(
-                f"No data found for {dtype} conversion at '{file_path}'."
-            )
+    # Split the data_type string by commas
+    data_types = [dtype.strip() for dtype in data_type.split(",")]
+
+    for dtype in data_types:
+        input_file = Path(input_file)
+        if not input_file.exists():
+            print(f"No data found for {dtype} conversion at '{input_file}'.")
+            continue
 
         try:
-            with file_path.open("r", encoding="utf-8") as f:
+            with input_file.open("r", encoding="utf-8") as f:
                 data = json.load(f)
 
         except (IOError, json.JSONDecodeError) as e:
-            print(f"Error reading '{file_path}': {e}")
+            print(f"Error reading '{input_file}': {e}")
             continue
 
+        # Determine the delimiter based on output type
         delimiter = "," if output_type == "csv" else "\t"
-        final_output_dir = output_dir / normalized_language["language"].capitalize()
+
+        final_output_dir = (
+            Path(output_dir) / normalized_language["language"].capitalize()
+        )
         final_output_dir.mkdir(parents=True, exist_ok=True)
 
         output_file = final_output_dir / f"{dtype}.{output_type}"
@@ -186,19 +248,67 @@ def convert_to_csv_or_tsv(
         try:
             with output_file.open("w", newline="", encoding="utf-8") as file:
                 writer = csv.writer(file, delimiter=delimiter)
+
+                # Handle different JSON structures based on the format
                 if isinstance(data, dict):
-                    writer.writerow(data.keys())
-                    writer.writerow(data.values())
+                    first_key = list(data.keys())[0]
 
-                elif isinstance(data, list):
-                    for item in data:
-                        if isinstance(item, dict):
-                            writer.writerow(item.values())
+                    if isinstance(data[first_key], dict):
+                        # Handle case: { key: { value1: ..., value2: ... } }
+                        columns = set()
+                        for value in data.values():
+                            columns.update(value.keys())
+                        writer.writerow([dtype[:-1]] + list(columns))
 
-                        else:
-                            writer.writerow([item])
-                else:
-                    print(f"Unsupported data format for {output_type} export.")
+                        for key, value in data.items():
+                            row = [key] + [value.get(col, "") for col in columns]
+                            writer.writerow(row)
+
+                    elif isinstance(data[first_key], list):
+                        if all(isinstance(item, dict) for item in data[first_key]):
+                            # Handle case: { key: [ { value1: ..., value2: ... } ] }
+                            if "emoji" in data[first_key][0]:  # Emoji specific case
+                                columns = ["word", "emoji", "is_base", "rank"]
+                                writer.writerow(columns)
+
+                                for key, value in data.items():
+                                    for item in value:
+                                        row = [
+                                            key,
+                                            item.get("emoji", ""),
+                                            item.get("is_base", ""),
+                                            item.get("rank", ""),
+                                        ]
+                                        writer.writerow(row)
+                            else:
+                                columns = [dtype[:-1]] + list(data[first_key][0].keys())
+                                writer.writerow(columns)
+
+                                for key, value in data.items():
+                                    for item in value:
+                                        row = [key] + [
+                                            item.get(col, "") for col in columns[1:]
+                                        ]
+                                        writer.writerow(row)
+
+                        elif all(isinstance(item, str) for item in data[first_key]):
+                            # Handle case: { key: [value1, value2, ...] }
+                            writer.writerow(
+                                [dtype[:-1]]
+                                + [
+                                    f"autosuggestion_{i+1}"
+                                    for i in range(len(data[first_key]))
+                                ]
+                            )
+                            for key, value in data.items():
+                                row = [key] + value
+                                writer.writerow(row)
+
+                    else:
+                        # Handle case: { key: value }
+                        writer.writerow([dtype[:-1], "value"])
+                        for key, value in data.items():
+                            writer.writerow([key, value])
 
         except IOError as e:
             print(f"Error writing to '{output_file}': {e}")
@@ -213,8 +323,10 @@ def convert_to_csv_or_tsv(
 def convert_to_sqlite(
     language: str,
     data_type: str,
-    output_dir: Path,
-    overwrite: bool,
+    output_type: str,
+    input_file: str = None,
+    output_dir: str = None,
+    overwrite: bool = False,
 ) -> None:
     """
     Converts a Scribe-Data output file to an SQLite file.
@@ -225,9 +337,15 @@ def convert_to_sqlite(
             The language of the file to convert.
 
         data_type : str
-            The data type to of the file to convert.
+            The data type of the file to convert.
 
-        output_dir : str
+        output_type : str
+            The output format, should be "sqlite".
+
+        input_file : Path
+            The input file path for the data to be converted.
+
+        output_dir : Path
             The output directory path for results.
 
         overwrite : bool
@@ -240,7 +358,10 @@ def convert_to_sqlite(
     if not language:
         raise ValueError("Language must be specified for SQLite conversion.")
 
-    languages = [language]
+    if not input_file.exists():
+        raise ValueError(f"Input file does not exist: {input_file}")
+
+    languages = [language.lower()]
     specific_tables = [data_type] if data_type else None
 
     if output_dir:
@@ -248,72 +369,22 @@ def convert_to_sqlite(
         if not output_dir.exists():
             output_dir.mkdir(parents=True, exist_ok=True)
 
-    print(f"Converting data for language: {language}, data type: {data_type} to SQLite")
+    print(
+        f"Converting data for language: {language}, data type: {data_type} to {output_type}"
+    )
     data_to_sqlite(languages, specific_tables)
 
-    if output_dir:
-        source_file = f"{get_language_iso(language).upper()}LanguageData.sqlite"
-        source_path = Path(DEFAULT_SQLITE_EXPORT_DIR) / source_file
-        target_path = output_dir / source_file
-        if source_path.exists():
-            if target_path.exists() and not overwrite:
-                print(f"File {target_path} already exists. Use --overwrite to replace.")
+    source_file = f"{get_language_iso(language).upper()}LanguageData.sqlite"
+    source_path = input_file.parent / source_file
+    target_path = output_dir / source_file
 
-            else:
-                shutil.copy(source_path, target_path)
-                print(f"SQLite database copied to: {target_path}")
-
+    if source_path.exists():
+        if target_path.exists() and not overwrite:
+            print(f"File {target_path} already exists. Use --overwrite to replace.")
         else:
-            print(f"Warning: SQLite file not found at {source_path}")
-
+            shutil.copy(source_path, target_path)
+            print(f"SQLite database copied to: {target_path}")
     else:
-        print("No output directory specified. SQLite file remains in default location.")
+        print(f"Warning: SQLite file not found at {source_path}")
 
-
-# MARK: Convert
-
-
-def convert(
-    language: str, data_type: str, output_dir: str, overwrite: bool, output_type: str
-):
-    """
-    Converts a Scribe-Data output file to a different file type.
-
-    Parameters
-    ----------
-        output_type : str
-            The file type to convert to (CSV or TSV).
-
-        language : str
-            The language of the file to convert.
-
-        data_type : str
-            The data type to of the file to convert.
-
-        output_dir : str
-            The output directory path for results.
-
-        overwrite : bool
-            Whether to overwrite existing files.
-
-    Returns
-    -------
-        A SQLite file saved in the given location.
-    """
-    if output_dir:
-        output_dir = Path(output_dir).resolve()
-        if not output_dir.exists():
-            output_dir.mkdir(parents=True, exist_ok=True)
-
-        if output_type == "json" or output_type is None:
-            export_json(language, data_type, output_dir, overwrite)
-
-        elif output_type in {"csv", "tsv"}:
-            convert_to_csv_or_tsv(
-                language, data_type, output_dir, overwrite, output_type
-            )
-
-        else:
-            raise ValueError(
-                "Unsupported output type. Please use 'json', 'csv', or 'tsv'."
-            )
+    print("SQLite file conversion complete.")

--- a/src/scribe_data/cli/convert.py
+++ b/src/scribe_data/cli/convert.py
@@ -29,6 +29,7 @@ from typing import List, Union
 from scribe_data.cli.cli_utils import language_map
 from scribe_data.load.data_to_sqlite import data_to_sqlite
 from scribe_data.utils import (
+    DEFAULT_SQLITE_EXPORT_DIR,
     get_language_iso,
 )
 
@@ -325,7 +326,7 @@ def convert_to_sqlite(
     data_type: str,
     output_type: str,
     input_file: str = None,
-    output_dir: str = None,
+    output_dir: str = DEFAULT_SQLITE_EXPORT_DIR,
     overwrite: bool = False,
 ) -> None:
     """
@@ -358,16 +359,21 @@ def convert_to_sqlite(
     if not language:
         raise ValueError("Language must be specified for SQLite conversion.")
 
+    if input_file:
+        input_file = Path(input_file)
     if not input_file.exists():
         raise ValueError(f"Input file does not exist: {input_file}")
 
-    languages = [language.lower()]
+    languages = [language]
     specific_tables = [data_type] if data_type else None
 
-    if output_dir:
+    if output_dir is None:
+        output_dir = Path(DEFAULT_SQLITE_EXPORT_DIR)
+    else:
         output_dir = Path(output_dir)
-        if not output_dir.exists():
-            output_dir.mkdir(parents=True, exist_ok=True)
+
+    if not output_dir.exists():
+        output_dir.mkdir(parents=True, exist_ok=True)
 
     print(
         f"Converting data for language: {language}, data type: {data_type} to {output_type}"

--- a/src/scribe_data/cli/get.py
+++ b/src/scribe_data/cli/get.py
@@ -40,6 +40,7 @@ def get_data(
     overwrite: bool = False,
     outputs_per_entry: int = None,
     all: bool = False,
+    interactive: bool = False,
 ) -> None:
     """
     Function for controlling the data get process for the CLI.
@@ -61,11 +62,14 @@ def get_data(
         outputs_per_entry : str
             How many outputs should be generated per data entry.
 
-        overwrite : bool
-            Whether to overwrite existing files (default: False).
+        overwrite : bool (default: False)
+            Whether to overwrite existing files.
 
         all : bool
             Get all languages and data types.
+
+        interactive : bool (default: False)
+            Whether it's running in interactive mode.
 
     Returns
     -------
@@ -125,6 +129,7 @@ def get_data(
             data_type=data_type,
             output_dir=output_dir,
             overwrite=overwrite,
+            interactive=interactive,
         )
         subprocess_result = True
 
@@ -140,6 +145,8 @@ def get_data(
         print(
             f"Updated data was saved in: {Path(output_dir).resolve()}.",
         )
+        if interactive:
+            return True
 
     # The emoji keywords process has failed.
     elif data_type in {"emoji-keywords", "emoji_keywords"}:

--- a/src/scribe_data/cli/main.py
+++ b/src/scribe_data/cli/main.py
@@ -219,7 +219,6 @@ def main() -> None:
         "-od",
         "--output-dir",
         type=Path,
-        required=True,
         help="The directory where the output file will be saved.",
     )
     convert_parser.add_argument(

--- a/src/scribe_data/cli/main.py
+++ b/src/scribe_data/cli/main.py
@@ -22,8 +22,13 @@ Setup and commands for the Scribe-Data command line interface.
 
 #!/usr/bin/env python3
 import argparse
+from pathlib import Path
 
-from scribe_data.cli.convert import convert_to_csv_or_tsv, convert_to_sqlite
+from scribe_data.cli.convert import (
+    convert_to_csv_or_tsv,
+    convert_to_json,
+    convert_to_sqlite,
+)
 from scribe_data.cli.get import get_data
 from scribe_data.cli.interactive import start_interactive_mode
 from scribe_data.cli.list import list_wrapper
@@ -179,22 +184,56 @@ def main() -> None:
         epilog=CLI_EPILOG,
         formatter_class=lambda prog: argparse.HelpFormatter(prog, max_help_position=60),
     )
-    convert_parser._actions[0].help = "Show this help message and exit."
+
+    # Setting up the arguments for the convert command
     convert_parser.add_argument(
-        "-f", "--file", type=str, help="The file to convert to a new type."
+        "-lang",
+        "--language",
+        type=str,
+        required=True,
+        help="The language of the file to convert.",
+    )
+    convert_parser.add_argument(
+        "-dt",
+        "--data-type",
+        type=str,
+        required=True,
+        help="The data type(s) of the file to convert (e.g., noun, verb).",
+    )
+    convert_parser.add_argument(
+        "-if",
+        "--input-file",
+        type=Path,
+        required=True,
+        help="The path to the input file to convert.",
     )
     convert_parser.add_argument(
         "-ot",
         "--output-type",
         type=str,
         choices=["json", "csv", "tsv", "sqlite"],
+        required=True,
         help="The output file type.",
+    )
+    convert_parser.add_argument(
+        "-od",
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="The directory where the output file will be saved.",
+    )
+    convert_parser.add_argument(
+        "-o",
+        "--overwrite",
+        action="store_true",
+        help="Whether to overwrite existing files (default: False).",
     )
     convert_parser.add_argument(
         "-ko",
         "--keep-original",
-        action="store_false",
-        help="Whether to keep the file to be converted (default: True).",
+        action="store_true",
+        default=True,
+        help="Whether to keep the original file to be converted (default: True).",
     )
 
     # MARK: Setup CLI
@@ -210,7 +249,9 @@ def main() -> None:
         return
 
     if args.command in ["list", "l"]:
-        list_wrapper(args.language, args.data_type, args.all)
+        list_wrapper(
+            language=args.language, data_type=args.data_type, all_bool=args.all
+        )
 
     elif args.command in ["get", "g"]:
         if args.interactive:
@@ -233,18 +274,32 @@ def main() -> None:
     elif args.command in ["convert", "c"]:
         if args.output_type in ["csv", "tsv"]:
             convert_to_csv_or_tsv(
-                args.language,
-                args.data_type,
-                args.output_dir,
-                args.overwrite,
+                language=args.language,
+                data_type=args.data_type,
+                output_type=args.output_type,
+                input_file=args.input_file,
+                output_dir=args.output_dir,
+                overwrite=args.overwrite,
             )
 
         elif args.output_type == "sqlite":
             convert_to_sqlite(
-                args.language,
-                args.data_type,
-                args.output_dir,
-                args.overwrite,
+                language=args.language,
+                data_type=args.data_type,
+                output_type=args.output_type,
+                input_file=args.input_file,
+                output_dir=args.output_dir,
+                overwrite=args.overwrite,
+            )
+
+        elif args.output_type == "json":
+            convert_to_json(
+                language=args.language,
+                data_type=args.data_type,
+                output_type=args.output_type,
+                input_file=args.input_file,
+                output_dir=args.output_dir,
+                overwrite=args.overwrite,
             )
 
     else:

--- a/src/scribe_data/language_data_extraction/Hebrew/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/language_data_extraction/Hebrew/adjectives/query_adjectives.sparql
@@ -1,0 +1,106 @@
+# tool: scribe-data
+# All Hebrew (Q9288) adjectives.
+# Enter this query at https://query.wikidata.org/.
+
+SELECT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
+  ?adjective
+  ?femSingular
+  ?femSingularConstruct
+  ?femPlural
+  ?femPluralConstruct
+  ?masSingular
+  ?masSingularConstruct
+  ?masPlural
+  ?masPluralConstruct
+
+WHERE {
+  ?lexeme dct:language wd:Q9288 ;
+    wikibase:lexicalCategory wd:Q34698 ;
+    wikibase:lemma ?adjective .
+    FILTER(lang(?adjective) = "he")
+
+  # MARK: Feminine
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?femSingularForm .
+    ?femSingularForm ontolex:representation ?femSingular ;
+      wikibase:grammaticalFeature wd:Q1775415 ;
+      wikibase:grammaticalFeature wd:Q110786 ;
+      FILTER NOT EXISTS {
+        ?femSingularForm wikibase:grammaticalFeature wd:Q1641446 .
+      }
+      FILTER(lang(?femSingular) = "he")
+  } .
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?femSingularConstructForm .
+    ?femSingularConstructForm ontolex:representation ?femSingularConstruct ;
+      wikibase:grammaticalFeature wd:Q1775415 ;
+      wikibase:grammaticalFeature wd:Q110786 ;
+      wikibase:grammaticalFeature wd:Q1641446 ;
+      FILTER(lang(?femSingularConstruct) = "he")
+  } .
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?femPluralForm .
+    ?femPluralForm ontolex:representation ?femPlural ;
+      wikibase:grammaticalFeature wd:Q1775415 ;
+      wikibase:grammaticalFeature wd:Q146786 ;
+      FILTER NOT EXISTS {
+        ?femPluralForm wikibase:grammaticalFeature wd:Q1641446 .
+      }
+      FILTER(lang(?femPlural) = "he")
+  } .
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?femPluralConstructForm .
+    ?femPluralConstructForm ontolex:representation ?femPluralConstruct ;
+      wikibase:grammaticalFeature wd:Q1775415 ;
+      wikibase:grammaticalFeature wd:Q146786 ;
+      wikibase:grammaticalFeature wd:Q1641446 ;
+      FILTER(lang(?femPluralConstruct) = "he")
+  } .
+
+  # MARK: Masculine
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?masSingularForm .
+    ?masSingularForm ontolex:representation ?masSingular ;
+      wikibase:grammaticalFeature wd:Q499327 ;
+      wikibase:grammaticalFeature wd:Q110786 ;
+      FILTER NOT EXISTS {
+        ?masSingularForm wikibase:grammaticalFeature wd:Q1641446 .
+      }
+      FILTER(lang(?masSingular) = "he")
+  } .
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?masSingularConstructForm .
+    ?masSingularConstructForm ontolex:representation ?masSingularConstruct ;
+      wikibase:grammaticalFeature wd:Q499327 ;
+      wikibase:grammaticalFeature wd:Q110786 ;
+      wikibase:grammaticalFeature wd:Q1641446 ;
+      FILTER(lang(?masSingularConstruct) = "he")
+  } .
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?masPluralForm .
+    ?masPluralForm ontolex:representation ?masPlural ;
+      wikibase:grammaticalFeature wd:Q499327 ;
+      wikibase:grammaticalFeature wd:Q146786 ;
+      FILTER NOT EXISTS {
+        ?masPluralForm wikibase:grammaticalFeature wd:Q1641446 .
+      }
+      FILTER(lang(?masPlural) = "he")
+  } .
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?masPluralConstructForm .
+    ?masPluralConstructForm ontolex:representation ?masPluralConstruct ;
+      wikibase:grammaticalFeature wd:Q499327 ;
+      wikibase:grammaticalFeature wd:Q146786 ;
+      wikibase:grammaticalFeature wd:Q1641446 ;
+      FILTER(lang(?masPluralConstruct) = "he")
+  } .
+}

--- a/src/scribe_data/language_data_extraction/Hebrew/adverbs/query_adverbs.sparql
+++ b/src/scribe_data/language_data_extraction/Hebrew/adverbs/query_adverbs.sparql
@@ -10,4 +10,5 @@ WHERE {
   ?lexeme dct:language wd:Q9288 ;
     wikibase:lexicalCategory wd:Q380057 ;
     wikibase:lemma ?adverb .
+    FILTER(lang(?adverb) = "he")
 }

--- a/src/scribe_data/language_data_extraction/Hebrew/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/language_data_extraction/Hebrew/verbs/query_verbs_1.sparql
@@ -22,6 +22,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q192613 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?presSF) = "he")
   } .
 
   # Singular Masculine
@@ -31,6 +32,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q192613 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?presSM) = "he")
   } .
 
   # Plural Feminine
@@ -40,6 +42,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q192613 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?presPF) = "he")
   } .
 
   # Plural Masculine
@@ -49,5 +52,6 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q192613 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?presPM) = "he")
   } .
 }

--- a/src/scribe_data/language_data_extraction/Hebrew/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/language_data_extraction/Hebrew/verbs/query_verbs_2.sparql
@@ -21,6 +21,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q22716 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?impSPSM) = "he")
   } .
 
   # TPS Masculine
@@ -31,6 +32,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q22716 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?impSPSM) = "he")
   } .
 
   # TPP Feminine
@@ -41,6 +43,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q22716 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?impSPPF) = "he")
   } .
 
   # TPP Masculine
@@ -51,5 +54,6 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q22716 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?impSPPM) = "he")
   } .
 }

--- a/src/scribe_data/language_data_extraction/Hebrew/verbs/query_verbs_3.sparql
+++ b/src/scribe_data/language_data_extraction/Hebrew/verbs/query_verbs_3.sparql
@@ -20,6 +20,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q21714344 ;
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q1994301 ;
+      FILTER(lang(?pastTPP) = "he")
   } .
 
   # SPS Feminine
@@ -30,6 +31,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q1994301 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?pastSPSF) = "he")
   } .
 
   # SPS Masculine
@@ -40,6 +42,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q1994301 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?pastSPSM) = "he")
   } .
 
   # TPS Feminine
@@ -50,6 +53,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q1994301 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?pastTPSF) = "he")
   } .
 
   # TPS Masculine
@@ -60,6 +64,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q1994301 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?pastTPSM) = "he")
   } .
 
   # FPP
@@ -69,6 +74,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q21714344 ;
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q1994301 ;
+      FILTER(lang(?pastFPP) = "he")
   } .
 
   # SPP Feminine
@@ -79,6 +85,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q1994301 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?pastSPPF) = "he")
   } .
 
   # SPP Masculine
@@ -89,6 +96,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q1994301 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?pastSPPM) = "he")
   } .
 
   # TPP Feminine
@@ -99,6 +107,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q1994301 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?pastTPPF) = "he")
   } .
 
   # TPP Masculine
@@ -109,5 +118,6 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q1994301 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?pastTPPM) = "he")
   } .
 }

--- a/src/scribe_data/language_data_extraction/Hebrew/verbs/query_verbs_4.sparql
+++ b/src/scribe_data/language_data_extraction/Hebrew/verbs/query_verbs_4.sparql
@@ -20,6 +20,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q21714344 ;
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q501405 ;
+      FILTER(lang(?futFPS) = "he")
   } .
 
   # SPS Feminine
@@ -30,6 +31,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q501405 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?futSPSF) = "he")
   } .
 
   # SPS Masculine
@@ -40,6 +42,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q501405 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?futSPSM) = "he")
   } .
 
   # TPS Feminine
@@ -50,6 +53,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q501405 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?futTPSF) = "he")
   } .
 
   # TPS Masculine
@@ -60,6 +64,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q501405 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?futTPSM) = "he")
   } .
 
   # FPP
@@ -69,6 +74,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q21714344 ;
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q501405 ;
+      FILTER(lang(?futFPP) = "he")
   } .
 
   # SPP Feminine
@@ -79,6 +85,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q501405 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?futSPPF) = "he")
   } .
 
   # SPP Masculine
@@ -89,6 +96,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q501405 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?futSPPM) = "he")
   } .
 
   # TPP Feminine
@@ -99,6 +107,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q501405 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?futTPPF) = "he")
   } .
 
   # TPP Masculine
@@ -109,5 +118,6 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q501405 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?futTPPM) = "he")
   } .
 }

--- a/src/scribe_data/language_data_extraction/Spanish/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/language_data_extraction/Spanish/adjectives/query_adjectives.sparql
@@ -6,12 +6,12 @@ SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?adjective
   ?femSingular
-  ?femPlural
   ?femSingularSuperlative
+  ?femPlural
   ?femPluralSuperlative
   ?masSingular
-  ?masPlural
   ?masSingularSuperlative
+  ?masPlural
   ?masPluralSuperlative
 
 WHERE {
@@ -27,17 +27,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q1775415 ;
       wikibase:grammaticalFeature wd:Q110786 .
       FILTER NOT EXISTS {
-        ?femSingular wikibase:grammaticalFeature wd:Q1817208 .
-      }
-  }
-
-  OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?femPluralForm .
-    ?femPluralForm ontolex:representation ?femPlural ;
-      wikibase:grammaticalFeature wd:Q1775415 ;
-      wikibase:grammaticalFeature wd:Q146786 .
-      FILTER NOT EXISTS {
-        ?femPlural wikibase:grammaticalFeature wd:Q1817208 .
+        ?femSingularForm wikibase:grammaticalFeature wd:Q1817208 .
       }
   }
 
@@ -47,6 +37,16 @@ WHERE {
       wikibase:grammaticalFeature wd:Q1775415 ;
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q1817208 .
+  }
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?femPluralForm .
+    ?femPluralForm ontolex:representation ?femPlural ;
+      wikibase:grammaticalFeature wd:Q1775415 ;
+      wikibase:grammaticalFeature wd:Q146786 .
+      FILTER NOT EXISTS {
+        ?femPluralForm wikibase:grammaticalFeature wd:Q1817208 .
+      }
   }
 
   OPTIONAL {
@@ -65,17 +65,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q499327 ;
       wikibase:grammaticalFeature wd:Q110786 .
       FILTER NOT EXISTS {
-        ?masSingular wikibase:grammaticalFeature wd:Q1817208 .
-      }
-  }
-
-  OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?masPluralForm .
-    ?masPluralForm ontolex:representation ?masPlural ;
-      wikibase:grammaticalFeature wd:Q499327 ;
-      wikibase:grammaticalFeature wd:Q146786 .
-      FILTER NOT EXISTS {
-        ?masPlural wikibase:grammaticalFeature wd:Q1817208 .
+        ?masSingularForm wikibase:grammaticalFeature wd:Q1817208 .
       }
   }
 
@@ -85,6 +75,16 @@ WHERE {
       wikibase:grammaticalFeature wd:Q499327 ;
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q1817208 .
+  }
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?masPluralForm .
+    ?masPluralForm ontolex:representation ?masPlural ;
+      wikibase:grammaticalFeature wd:Q499327 ;
+      wikibase:grammaticalFeature wd:Q146786 .
+      FILTER NOT EXISTS {
+        ?masPluralForm wikibase:grammaticalFeature wd:Q1817208 .
+      }
   }
 
   OPTIONAL {

--- a/src/scribe_data/wikidata/query_data.py
+++ b/src/scribe_data/wikidata/query_data.py
@@ -24,6 +24,7 @@ import json
 import os
 import subprocess
 import sys
+from http.client import IncompleteRead
 from pathlib import Path
 from urllib.error import HTTPError
 
@@ -215,14 +216,18 @@ def query_data(
         try:
             results = sparql.query().convert()
 
-        except HTTPError as err:
-            print(f"HTTPError with {q}: {err}")
+        except HTTPError as http_err:
+            print(f"HTTPError with {q}: {http_err}")
+
+        except IncompleteRead as read_err:
+            print(f"Incomplete read error with {q}: {read_err}")
 
         if results is None:
             print(f"Nothing returned by the WDQS server for {q}")
 
             # Allow for a query to be reran up to two times.
             if queries_to_run.count(q) < 3:
+                print("The query will be retried.")
                 queries_to_run.append(q)
 
         else:

--- a/src/scribe_data/wikidata/query_data.py
+++ b/src/scribe_data/wikidata/query_data.py
@@ -87,6 +87,7 @@ def query_data(
     data_type: str = None,
     output_dir: str = None,
     overwrite: bool = None,
+    interactive: bool = False,
 ):
     """
     Queries language data from the Wikidata lexicographical data.
@@ -102,8 +103,8 @@ def query_data(
         output_dir : str
             The output directory path for results.
 
-        overwrite : bool
-            Whether to overwrite existing files (default: False).
+        overwrite : bool (default: False)
+            Whether to overwrite existing files.
 
     Returns
     -------
@@ -155,6 +156,8 @@ def query_data(
         queries_to_run,
         desc="Data updated",
         unit="process",
+        disable=interactive,
+        colour="MAGENTA",
     ):
         lang = q.parent.parent.name
         target_type = q.parent.name
@@ -172,24 +175,25 @@ def query_data(
                 for file in existing_files:
                     file.unlink()
             else:
-                print(
-                    f"\nExisting file(s) found for {lang} {target_type} in the {output_dir} directory:\n"
-                )
-                for i, file in enumerate(existing_files, 1):
-                    print(f"{i}. {file.name}")
+                if not interactive:
+                    print(
+                        f"\nExisting file(s) found for {lang} {target_type} in the {output_dir} directory:\n"
+                    )
+                    for i, file in enumerate(existing_files, 1):
+                        print(f"{i}. {file.name}")
 
-                # choice = input(
-                #     "\nChoose an option:\n1. Overwrite existing (press 'o')\n2. Keep all (press 'k')\n3. Skip process (press anything else)\nEnter your choice: "
-                # )
+                    # choice = input(
+                    #     "\nChoose an option:\n1. Overwrite existing (press 'o')\n2. Keep all (press 'k')\n3. Skip process (press anything else)\nEnter your choice: "
+                    # )
 
-                choice = input(
-                    "\nChoose an option:\n1. Overwrite existing data (press 'o')\n2. Skip process (press anything else)\nEnter your choice: "
-                )
+                    choice = input(
+                        "\nChoose an option:\n1. Overwrite existing data (press 'o')\n2. Skip process (press anything else)\nEnter your choice: "
+                    )
 
-                if choice.lower() == "o":
-                    print("Removing existing files ...")
-                    for file in existing_files:
-                        file.unlink()
+                    if choice.lower() == "o":
+                        print("Removing existing files ...")
+                        for file in existing_files:
+                            file.unlink()
 
                 # elif choice in ["k", "K"]:
                 #     timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -21,9 +21,11 @@ Tests for the CLI convert functionality.
 """
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from scribe_data.cli.convert import convert_to_sqlite
+from scribe_data.cli.convert import (
+    convert_to_sqlite,
+)
 
 
 class TestConvert(unittest.TestCase):
@@ -48,17 +50,27 @@ class TestConvert(unittest.TestCase):
     @patch("scribe_data.cli.convert.Path")
     @patch("scribe_data.cli.convert.data_to_sqlite")
     def test_convert_to_sqlite_no_output_dir(self, mock_data_to_sqlite, mock_path):
+        # Create a mock for input file
+        mock_input_file = MagicMock()
+        mock_input_file.exists.return_value = True
+
+        mock_path.return_value = mock_input_file
+
+        # source and destination paths
+        mock_input_file.parent = MagicMock()
+        mock_input_file.parent.__truediv__.return_value = MagicMock()
+        mock_input_file.parent.__truediv__.return_value.exists.return_value = False
+
         convert_to_sqlite(
             language="english",
             data_type="nouns",
-            input_file="file",
+            input_file=mock_input_file,
             output_type="sqlite",
             output_dir=None,
             overwrite=True,
         )
 
         mock_data_to_sqlite.assert_called_with(["english"], ["nouns"])
-        mock_path.assert_not_called()
 
     @patch("scribe_data.cli.convert.Path")
     @patch("scribe_data.cli.convert.data_to_sqlite")

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -21,10 +21,9 @@ Tests for the CLI convert functionality.
 """
 
 import unittest
-from pathlib import Path
 from unittest.mock import patch
 
-from scribe_data.cli.convert import convert_to_sqlite, export_json
+from scribe_data.cli.convert import convert_to_sqlite
 
 
 class TestConvert(unittest.TestCase):
@@ -34,7 +33,14 @@ class TestConvert(unittest.TestCase):
     def test_convert_to_sqlite(self, mock_shutil_copy, mock_data_to_sqlite, mock_path):
         mock_path.return_value.exists.return_value = True
 
-        convert_to_sqlite("english", "nouns", "/output", True)
+        convert_to_sqlite(
+            language="english",
+            data_type="nouns",
+            input_file="file",
+            output_type="sqlite",
+            output_dir="/output",
+            overwrite=True,
+        )
 
         mock_data_to_sqlite.assert_called_with(["english"], ["nouns"])
         mock_shutil_copy.assert_called()
@@ -42,7 +48,14 @@ class TestConvert(unittest.TestCase):
     @patch("scribe_data.cli.convert.Path")
     @patch("scribe_data.cli.convert.data_to_sqlite")
     def test_convert_to_sqlite_no_output_dir(self, mock_data_to_sqlite, mock_path):
-        convert_to_sqlite("english", "nouns", None, True)
+        convert_to_sqlite(
+            language="english",
+            data_type="nouns",
+            input_file="file",
+            output_type="sqlite",
+            output_dir=None,
+            overwrite=True,
+        )
 
         mock_data_to_sqlite.assert_called_with(["english"], ["nouns"])
         mock_path.assert_not_called()
@@ -57,18 +70,24 @@ class TestConvert(unittest.TestCase):
         mock_get_language_iso.return_value = "en"
         mock_path.return_value.exists.return_value = True
 
-        convert_to_sqlite("English", "data_type", "/output", True)
+        convert_to_sqlite(
+            language="English",
+            data_type="data_type",
+            input_file="file",
+            output_type="sqlite",
+            output_dir="/output",
+            overwrite=True,
+        )
 
         mock_data_to_sqlite.assert_called_with(["English"], ["data_type"])
         mock_copy.assert_called()
 
-    @patch("scribe_data.cli.convert.language_map")
-    def test_export_json_invalid_language(self, mock_language_map):
-        mock_language_map.get.return_value = None
-
-        with self.assertRaises(ValueError):
-            export_json("invalid", "data_type", Path("/output"), True)
-
     def test_convert_to_sqlite_no_language(self):
         with self.assertRaises(ValueError):
-            convert_to_sqlite(None, "data_type", "/output", True)
+            convert_to_sqlite(
+                language=None,
+                data_type="data_type",
+                output_type="sqlite",
+                output_dir="/output",
+                overwrite=True,
+            )

--- a/tests/cli/test_get.py
+++ b/tests/cli/test_get.py
@@ -57,6 +57,7 @@ class TestGetData(unittest.TestCase):
             data_type=["nouns"],
             output_dir="./test_output",
             overwrite=False,
+            interactive=False,
         )
 
     # MARK: Capitalized Language
@@ -69,6 +70,7 @@ class TestGetData(unittest.TestCase):
             data_type=["nouns"],
             output_dir="scribe_data_json_export",
             overwrite=False,
+            interactive=False,
         )
 
     # MARK: Lowercase Language
@@ -81,6 +83,7 @@ class TestGetData(unittest.TestCase):
             data_type=["nouns"],
             output_dir="scribe_data_json_export",
             overwrite=False,
+            interactive=False,
         )
 
     # MARK: Output Directory
@@ -95,6 +98,7 @@ class TestGetData(unittest.TestCase):
             data_type=["nouns"],
             output_dir="./custom_output_test",
             overwrite=False,
+            interactive=False,
         )
 
     # MARK: Overwrite is True
@@ -107,6 +111,7 @@ class TestGetData(unittest.TestCase):
             data_type=["verbs"],
             output_dir="scribe_data_json_export",
             overwrite=True,
+            interactive=False,
         )
 
     # MARK: Overwrite is False
@@ -118,10 +123,12 @@ class TestGetData(unittest.TestCase):
             data_type="verbs",
             overwrite=False,
             output_dir="./custom_output_test",
+            interactive=False,
         )
         mock_query_data.assert_called_once_with(
             languages=["English"],
             data_type=["verbs"],
             output_dir="./custom_output_test",
             overwrite=False,
+            interactive=False,
         )


### PR DESCRIPTION
### Contributor Checklist
- [✔️] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch.
### Description
This pull request adds functionality to convert data into CSV, TSV, and JSON formats. The changes include:
- Extension of the `convert_to_json` and `convert_to_csv_or_tsv` methods in `convert.py`.
- Updates to the CLI in `main.py` to support new conversion commands.
#### Example Commands:
1. **From JSON to CSV**:
   ```bash
   scribe-data convert --lan French --data-type translations --input-file ./fli/French/translations.json --output-type csv --output-dir ./converted/
2. **From CSV to JSON**:
   ```bash
   scribe-data convert --lan French --data-type translations --input-file ./converted/French/translations.csv --output-type json --output-dir ./converted/
3. **From JSON to TSV**:
   ```bash
   scribe-data convert --lan French --data-type translations --input-file ./fli/French/translations.json --output-type tsv --output-dir ./converted/ 
4. **From TSV to JSON**:
   ```bash
   scribe-data convert --lan French --data-type translations --input-file ./converted/French/translations.tsv --output-type json --output-dir ./converted/ 

I tested the changes by running the CLI commands and verifying that the output matched the expected formats. I want to get feedback on the approaches before implementing the code tests and the SQLite conversion support

### Related issue

- Decouple convert from get in Scribe-Data CLI #213
