### PR TITLE
Hebrew adjectives.

### DIFF
--- a/src/scribe_data/language_data_extraction/Hebrew/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/language_data_extraction/Hebrew/adjectives/query_adjectives.sparql
@@ -2,8 +2,7 @@
 # All Hebrew (Q9288) adjectives.
 # Enter this query at https://query.wikidata.org/.
 
-SELECT DISTINCT
-  ?lexeme
+SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?adjective
   ?femSingular

--- a/src/scribe_data/language_data_extraction/Hebrew/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/language_data_extraction/Hebrew/adjectives/query_adjectives.sparql
@@ -1,0 +1,13 @@
+# tool: scribe-data
+# All Hebrew (Q9288) adjectives.
+# Enter this query at https://query.wikidata.org/.
+
+SELECT DISTINCT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
+  (SAMPLE(?adjective) AS ?adjective)  # Use SAMPLE to select one adjective per lexeme
+WHERE {
+  ?lexeme dct:language wd:Q9288 ;
+          wikibase:lexicalCategory wd:Q34698 ;
+          wikibase:lemma ?adjective .
+}
+GROUP BY ?lexeme

--- a/src/scribe_data/language_data_extraction/Hebrew/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/language_data_extraction/Hebrew/adjectives/query_adjectives.sparql
@@ -3,41 +3,86 @@
 # Enter this query at https://query.wikidata.org/.
 
 SELECT DISTINCT
+  ?lexeme
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?adjective
   ?femSingular
-  ?masSingular
+  ?femSingularConstruct
   ?femPlural
+  ?femPluralConstruct
+  ?masSingular
+  ?masSingularConstruct
   ?masPlural
+  ?masPluralConstruct
 
 WHERE {
   ?lexeme dct:language wd:Q9288 ;
     wikibase:lexicalCategory wd:Q34698 ;
     wikibase:lemma ?adjective .
+    FILTER(lang(?adjective) = "he")
 
-  # Singular
+  # MARK: Feminine
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?femSingularForm .
     ?femSingularForm ontolex:representation ?femSingular ;
       wikibase:grammaticalFeature wd:Q1775415 ;
       wikibase:grammaticalFeature wd:Q110786 ;
+      FILTER NOT EXISTS {
+        ?femSingularForm wikibase:grammaticalFeature wd:Q1641446 .
+      }
+      FILTER(lang(?femSingular) = "he")
   } .
 
   OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?masSingularForm .
-    ?masSingularForm ontolex:representation ?masSingular ;
-      wikibase:grammaticalFeature wd:Q499327 ;
+    ?lexeme ontolex:lexicalForm ?femSingularConstructForm .
+    ?femSingularConstructForm ontolex:representation ?femSingularConstruct ;
+      wikibase:grammaticalFeature wd:Q1775415 ;
       wikibase:grammaticalFeature wd:Q110786 ;
+      wikibase:grammaticalFeature wd:Q1641446 ;
+      FILTER(lang(?femSingularConstruct) = "he")
   } .
-
-  # Plural
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?femPluralForm .
     ?femPluralForm ontolex:representation ?femPlural ;
       wikibase:grammaticalFeature wd:Q1775415 ;
       wikibase:grammaticalFeature wd:Q146786 ;
+      FILTER NOT EXISTS {
+        ?femPluralForm wikibase:grammaticalFeature wd:Q1641446 .
+      }
+      FILTER(lang(?femPlural) = "he")
+  } .
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?femPluralConstructForm .
+    ?femPluralConstructForm ontolex:representation ?femPluralConstruct ;
+      wikibase:grammaticalFeature wd:Q1775415 ;
+      wikibase:grammaticalFeature wd:Q146786 ;
+      wikibase:grammaticalFeature wd:Q1641446 ;
+      FILTER(lang(?femPluralConstruct) = "he")
+  } .
+
+  # MARK: Masculine
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?masSingularForm .
+    ?masSingularForm ontolex:representation ?masSingular ;
+      wikibase:grammaticalFeature wd:Q499327 ;
+      wikibase:grammaticalFeature wd:Q110786 ;
+      FILTER NOT EXISTS {
+        ?masSingularForm wikibase:grammaticalFeature wd:Q1641446 .
+      }
+      FILTER(lang(?masSingular) = "he")
+  } .
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?masSingularConstructForm .
+    ?masSingularConstructForm ontolex:representation ?masSingularConstruct ;
+      wikibase:grammaticalFeature wd:Q499327 ;
+      wikibase:grammaticalFeature wd:Q110786 ;
+      wikibase:grammaticalFeature wd:Q1641446 ;
+      FILTER(lang(?masSingularConstruct) = "he")
   } .
 
   OPTIONAL {
@@ -45,5 +90,18 @@ WHERE {
     ?masPluralForm ontolex:representation ?masPlural ;
       wikibase:grammaticalFeature wd:Q499327 ;
       wikibase:grammaticalFeature wd:Q146786 ;
+      FILTER NOT EXISTS {
+        ?masPluralForm wikibase:grammaticalFeature wd:Q1641446 .
+      }
+      FILTER(lang(?masPlural) = "he")
+  } .
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?masPluralConstructForm .
+    ?masPluralConstructForm ontolex:representation ?masPluralConstruct ;
+      wikibase:grammaticalFeature wd:Q499327 ;
+      wikibase:grammaticalFeature wd:Q146786 ;
+      wikibase:grammaticalFeature wd:Q1641446 ;
+      FILTER(lang(?masPluralConstruct) = "he")
   } .
 }

--- a/src/scribe_data/language_data_extraction/Hebrew/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/language_data_extraction/Hebrew/adjectives/query_adjectives.sparql
@@ -4,10 +4,46 @@
 
 SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
-  ?lemma
-WHERE {
-  ?lexeme dct:language wd:Q9288 ;  # Hebrew language
-          wikibase:lexicalCategory wd:Q34698 ;  # Adjective
-          wikibase:lemma ?lemma .
+  ?adjective
+  ?femSingular
+  ?masSingular
+  ?femPlural
+  ?masPlural
 
+WHERE {
+  ?lexeme dct:language wd:Q9288 ;
+    wikibase:lexicalCategory wd:Q34698 ;
+    wikibase:lemma ?adjective .
+
+  # Singular
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?femSingularForm .
+    ?femSingularForm ontolex:representation ?femSingular ;
+      wikibase:grammaticalFeature wd:Q1775415 ;
+      wikibase:grammaticalFeature wd:Q110786 ;
+  } .
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?masSingularForm .
+    ?masSingularForm ontolex:representation ?masSingular ;
+      wikibase:grammaticalFeature wd:Q499327 ;
+      wikibase:grammaticalFeature wd:Q110786 ;
+  } .
+
+  # Plural
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?femPluralForm .
+    ?femPluralForm ontolex:representation ?femPlural ;
+      wikibase:grammaticalFeature wd:Q1775415 ;
+      wikibase:grammaticalFeature wd:Q146786 ;
+  } .
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?masPluralForm .
+    ?masPluralForm ontolex:representation ?masPlural ;
+      wikibase:grammaticalFeature wd:Q499327 ;
+      wikibase:grammaticalFeature wd:Q146786 ;
+  } .
 }

--- a/src/scribe_data/language_data_extraction/Hebrew/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/language_data_extraction/Hebrew/adjectives/query_adjectives.sparql
@@ -4,10 +4,10 @@
 
 SELECT DISTINCT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
-  (SAMPLE(?adjective) AS ?adjective)  # Use SAMPLE to select one adjective per lexeme
+  ?lemma
 WHERE {
-  ?lexeme dct:language wd:Q9288 ;
-          wikibase:lexicalCategory wd:Q34698 ;
-          wikibase:lemma ?adjective .
+  ?lexeme dct:language wd:Q9288 ;  # Hebrew language
+          wikibase:lexicalCategory wd:Q34698 ;  # Adjective
+          wikibase:lemma ?lemma .
+
 }
-GROUP BY ?lexeme

--- a/src/scribe_data/language_data_extraction/Hebrew/adverbs/query_adverbs.sparql
+++ b/src/scribe_data/language_data_extraction/Hebrew/adverbs/query_adverbs.sparql
@@ -10,4 +10,5 @@ WHERE {
   ?lexeme dct:language wd:Q9288 ;
     wikibase:lexicalCategory wd:Q380057 ;
     wikibase:lemma ?adverb .
+    FILTER(lang(?adverb) = "he")
 }

--- a/src/scribe_data/language_data_extraction/Hebrew/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/language_data_extraction/Hebrew/verbs/query_verbs_1.sparql
@@ -22,6 +22,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q192613 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?presSF) = "he")
   } .
 
   # Singular Masculine
@@ -31,6 +32,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q192613 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?presSM) = "he")
   } .
 
   # Plural Feminine
@@ -40,6 +42,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q192613 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?presPF) = "he")
   } .
 
   # Plural Masculine
@@ -49,5 +52,6 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q192613 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?presPM) = "he")
   } .
 }

--- a/src/scribe_data/language_data_extraction/Hebrew/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/language_data_extraction/Hebrew/verbs/query_verbs_2.sparql
@@ -21,6 +21,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q22716 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?impSPSM) = "he")
   } .
 
   # TPS Masculine
@@ -31,6 +32,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q22716 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?impSPSM) = "he")
   } .
 
   # TPP Feminine
@@ -41,6 +43,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q22716 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?impSPPF) = "he")
   } .
 
   # TPP Masculine
@@ -51,5 +54,6 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q22716 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?impSPPM) = "he")
   } .
 }

--- a/src/scribe_data/language_data_extraction/Hebrew/verbs/query_verbs_3.sparql
+++ b/src/scribe_data/language_data_extraction/Hebrew/verbs/query_verbs_3.sparql
@@ -20,6 +20,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q21714344 ;
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q1994301 ;
+      FILTER(lang(?pastTPP) = "he")
   } .
 
   # SPS Feminine
@@ -30,6 +31,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q1994301 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?pastSPSF) = "he")
   } .
 
   # SPS Masculine
@@ -40,6 +42,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q1994301 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?pastSPSM) = "he")
   } .
 
   # TPS Feminine
@@ -50,6 +53,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q1994301 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?pastTPSF) = "he")
   } .
 
   # TPS Masculine
@@ -60,6 +64,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q1994301 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?pastTPSM) = "he")
   } .
 
   # FPP
@@ -69,6 +74,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q21714344 ;
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q1994301 ;
+      FILTER(lang(?pastFPP) = "he")
   } .
 
   # SPP Feminine
@@ -79,6 +85,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q1994301 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?pastSPPF) = "he")
   } .
 
   # SPP Masculine
@@ -89,6 +96,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q1994301 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?pastSPPM) = "he")
   } .
 
   # TPP Feminine
@@ -99,6 +107,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q1994301 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?pastTPPF) = "he")
   } .
 
   # TPP Masculine
@@ -109,5 +118,6 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q1994301 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?pastTPPM) = "he")
   } .
 }

--- a/src/scribe_data/language_data_extraction/Hebrew/verbs/query_verbs_4.sparql
+++ b/src/scribe_data/language_data_extraction/Hebrew/verbs/query_verbs_4.sparql
@@ -20,6 +20,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q21714344 ;
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q501405 ;
+      FILTER(lang(?futFPS) = "he")
   } .
 
   # SPS Feminine
@@ -30,6 +31,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q501405 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?futSPSF) = "he")
   } .
 
   # SPS Masculine
@@ -40,6 +42,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q501405 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?futSPSM) = "he")
   } .
 
   # TPS Feminine
@@ -50,6 +53,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q501405 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?futTPSF) = "he")
   } .
 
   # TPS Masculine
@@ -60,6 +64,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q501405 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?futTPSM) = "he")
   } .
 
   # FPP
@@ -69,6 +74,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q21714344 ;
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q501405 ;
+      FILTER(lang(?futFPP) = "he")
   } .
 
   # SPP Feminine
@@ -79,6 +85,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q501405 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?futSPPF) = "he")
   } .
 
   # SPP Masculine
@@ -89,6 +96,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q501405 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?futSPPM) = "he")
   } .
 
   # TPP Feminine
@@ -99,6 +107,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q501405 ;
       wikibase:grammaticalFeature wd:Q1775415 ;
+      FILTER(lang(?futTPPF) = "he")
   } .
 
   # TPP Masculine
@@ -109,5 +118,6 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146786 ;
       wikibase:grammaticalFeature wd:Q501405 ;
       wikibase:grammaticalFeature wd:Q499327 ;
+      FILTER(lang(?futTPPM) = "he")
   } .
 }

--- a/src/scribe_data/language_data_extraction/Spanish/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/language_data_extraction/Spanish/adjectives/query_adjectives.sparql
@@ -6,12 +6,12 @@ SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?adjective
   ?femSingular
-  ?femPlural
   ?femSingularSuperlative
+  ?femPlural
   ?femPluralSuperlative
   ?masSingular
-  ?masPlural
   ?masSingularSuperlative
+  ?masPlural
   ?masPluralSuperlative
 
 WHERE {
@@ -27,17 +27,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q1775415 ;
       wikibase:grammaticalFeature wd:Q110786 .
       FILTER NOT EXISTS {
-        ?femSingular wikibase:grammaticalFeature wd:Q1817208 .
-      }
-  }
-
-  OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?femPluralForm .
-    ?femPluralForm ontolex:representation ?femPlural ;
-      wikibase:grammaticalFeature wd:Q1775415 ;
-      wikibase:grammaticalFeature wd:Q146786 .
-      FILTER NOT EXISTS {
-        ?femPlural wikibase:grammaticalFeature wd:Q1817208 .
+        ?femSingularForm wikibase:grammaticalFeature wd:Q1817208 .
       }
   }
 
@@ -47,6 +37,16 @@ WHERE {
       wikibase:grammaticalFeature wd:Q1775415 ;
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q1817208 .
+  }
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?femPluralForm .
+    ?femPluralForm ontolex:representation ?femPlural ;
+      wikibase:grammaticalFeature wd:Q1775415 ;
+      wikibase:grammaticalFeature wd:Q146786 .
+      FILTER NOT EXISTS {
+        ?femPluralForm wikibase:grammaticalFeature wd:Q1817208 .
+      }
   }
 
   OPTIONAL {
@@ -65,17 +65,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q499327 ;
       wikibase:grammaticalFeature wd:Q110786 .
       FILTER NOT EXISTS {
-        ?masSingular wikibase:grammaticalFeature wd:Q1817208 .
-      }
-  }
-
-  OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?masPluralForm .
-    ?masPluralForm ontolex:representation ?masPlural ;
-      wikibase:grammaticalFeature wd:Q499327 ;
-      wikibase:grammaticalFeature wd:Q146786 .
-      FILTER NOT EXISTS {
-        ?masPlural wikibase:grammaticalFeature wd:Q1817208 .
+        ?masSingularForm wikibase:grammaticalFeature wd:Q1817208 .
       }
   }
 
@@ -85,6 +75,16 @@ WHERE {
       wikibase:grammaticalFeature wd:Q499327 ;
       wikibase:grammaticalFeature wd:Q110786 ;
       wikibase:grammaticalFeature wd:Q1817208 .
+  }
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?masPluralForm .
+    ?masPluralForm ontolex:representation ?masPlural ;
+      wikibase:grammaticalFeature wd:Q499327 ;
+      wikibase:grammaticalFeature wd:Q146786 .
+      FILTER NOT EXISTS {
+        ?masPluralForm wikibase:grammaticalFeature wd:Q1817208 .
+      }
   }
 
   OPTIONAL {


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This PR adds a file to `Hebrew/adjectives/query_adjectives.sparql` to extract all the Hebrew adjectives from the Wikidata website. Currently, the Hebrew directory supports extracting nouns, verbs, adverbs, and now adjectives.