### PR TITLE
add validate language and data type #307

### DIFF
--- a/src/scribe_data/cli/total.py
+++ b/src/scribe_data/cli/total.py
@@ -217,7 +217,7 @@ def get_total_lexemes(language, data_type, doPrint=True):
         validate_language_and_data_type(language_qid, data_type_qid)
 
     except ValueError as e:
-        print(e)
+        print(str(e))
         return
 
     query_template = """

--- a/src/scribe_data/cli/total.py
+++ b/src/scribe_data/cli/total.py
@@ -212,6 +212,12 @@ def get_total_lexemes(language, data_type, doPrint=True):
     else:
         data_type_qid = get_qid_by_input(data_type)
 
+    # Validate language and data type, raise error if invalid
+    try:
+        validate_language_and_data_type(language_qid, data_type_qid)
+    except ValueError as e:
+        print(str(e))
+        return  # Exit the function early if validation fails
     query_template = """
     SELECT
         (COUNT(DISTINCT ?lexeme) as ?total)
@@ -267,6 +273,22 @@ def get_total_lexemes(language, data_type, doPrint=True):
     else:
         print("Total number of lexemes: Not found")
         return None
+
+
+# MARK: Validate
+
+
+def validate_language_and_data_type(language, data_type):
+    """
+    Validates that the language and data type QIDs are not None.
+
+    Raises
+    ------
+    ValueError
+        If either the language or data type is invalid (None).
+    """
+    if language is None or data_type is None:
+        raise ValueError("Total number of lexemes: Not found")
 
 
 # MARK: Wrapper

--- a/src/scribe_data/cli/total.py
+++ b/src/scribe_data/cli/total.py
@@ -212,12 +212,14 @@ def get_total_lexemes(language, data_type, doPrint=True):
     else:
         data_type_qid = get_qid_by_input(data_type)
 
-    # Validate language and data type, raise error if invalid
+    # Validate language and data type, raise error if invalid.
     try:
         validate_language_and_data_type(language_qid, data_type_qid)
+
     except ValueError as e:
-        print(str(e))
-        return  # Exit the function early if validation fails
+        print(e)
+        return
+
     query_template = """
     SELECT
         (COUNT(DISTINCT ?lexeme) as ?total)
@@ -278,14 +280,22 @@ def get_total_lexemes(language, data_type, doPrint=True):
 # MARK: Validate
 
 
-def validate_language_and_data_type(language, data_type):
+def validate_language_and_data_type(language: str, data_type: str):
     """
     Validates that the language and data type QIDs are not None.
 
+    Parameters
+    ----------
+        language : str
+            The language to validate.
+
+        data_type : str
+            The data type to validate.
+
     Raises
     ------
-    ValueError
-        If either the language or data type is invalid (None).
+        ValueError
+            If either the language or data type is invalid (None).
     """
     if language is None or data_type is None:
         raise ValueError("Total number of lexemes: Not found")

--- a/tests/cli/test_total.py
+++ b/tests/cli/test_total.py
@@ -23,7 +23,11 @@ Tests for the CLI total functionality.
 import unittest
 from unittest.mock import MagicMock, call, patch
 
-from scribe_data.cli.total import get_qid_by_input, get_total_lexemes
+from scribe_data.cli.total import (
+    get_qid_by_input,
+    get_total_lexemes,
+    validate_language_and_data_type,
+)
 
 
 class TestTotalLexemes(unittest.TestCase):
@@ -151,3 +155,64 @@ class TestGetQidByInput(unittest.TestCase):
         mock_data_type_metadata.update(self.valid_data_types)
 
         self.assertIsNone(get_qid_by_input("invalid_data_type"))
+
+
+class TestValidateLanguageAndDataType(unittest.TestCase):
+    def setUp(self):
+        self.qid_mapping = {
+            "english": "Q1860",
+            "nouns": "Q1084",
+            "verbs": "Q24905",
+        }
+
+    def mock_get_qid(self, input_value):
+        """Returns QID based on the input language or data type."""
+        return self.qid_mapping.get(input_value.lower())
+
+    @patch("scribe_data.cli.total.get_qid_by_input")
+    def test_validate_language_and_data_type_valid(self, mock_get_qid):
+        mock_get_qid.side_effect = self.mock_get_qid
+
+        language_qid = mock_get_qid("English")
+        data_type_qid = mock_get_qid("nouns")
+
+        try:
+            validate_language_and_data_type(language_qid, data_type_qid)
+        except ValueError:
+            self.fail("validate_language_and_data_type raised ValueError unexpectedly!")
+
+    @patch("scribe_data.cli.total.get_qid_by_input")
+    def test_validate_language_and_data_type_invalid_language(self, mock_get_qid):
+        mock_get_qid.side_effect = self.mock_get_qid
+
+        language_qid = mock_get_qid("InvalidLanguage")
+        data_type_qid = mock_get_qid("nouns")
+
+        with self.assertRaises(ValueError) as context:
+            validate_language_and_data_type(language_qid, data_type_qid)
+
+        self.assertEqual(str(context.exception), "Total number of lexemes: Not found")
+
+    @patch("scribe_data.cli.total.get_qid_by_input")
+    def test_validate_language_and_data_type_invalid_data_type(self, mock_get_qid):
+        mock_get_qid.side_effect = self.mock_get_qid
+
+        language_qid = mock_get_qid("English")
+        data_type_qid = mock_get_qid("InvalidDataType")
+
+        with self.assertRaises(ValueError) as context:
+            validate_language_and_data_type(language_qid, data_type_qid)
+
+        self.assertEqual(str(context.exception), "Total number of lexemes: Not found")
+
+    @patch("scribe_data.cli.total.get_qid_by_input")
+    def test_validate_language_and_data_type_both_invalid(self, mock_get_qid):
+        mock_get_qid.side_effect = lambda x: None  # Simulate invalid inputs
+
+        language_qid = mock_get_qid("InvalidLanguage")
+        data_type_qid = mock_get_qid("InvalidDataType")
+
+        with self.assertRaises(ValueError) as context:
+            validate_language_and_data_type(language_qid, data_type_qid)
+
+        self.assertEqual(str(context.exception), "Total number of lexemes: Not found")

--- a/tests/cli/test_total.py
+++ b/tests/cli/test_total.py
@@ -178,6 +178,7 @@ class TestValidateLanguageAndDataType(unittest.TestCase):
 
         try:
             validate_language_and_data_type(language_qid, data_type_qid)
+
         except ValueError:
             self.fail("validate_language_and_data_type raised ValueError unexpectedly!")
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

This PR introduces a function to validate the language and data type. It raises an error to prevent get_total_lexemes from executing the query if either QID is None.

Tested this command

- `scribe-data total -l invalid_language -dt invalid_type`
- `scribe-data total -l english -dt invalid_type`
- `scribe-data total -l invalid_language -dt nouns`

All results `Total number of lexemes: Not found`.

Added some unit tests as well.
Feedbacks is appreciated. :)
### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #307 
