### PR TITLE
Expand Italian verbs query

### DIFF
--- a/src/scribe_data/language_data_extraction/Italian/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/language_data_extraction/Italian/verbs/query_verbs_1.sparql
@@ -65,40 +65,40 @@ WHERE {
     ?lexeme ontolex:lexicalForm ?pretFPSForm .
     ?pretFPSForm ontolex:representation ?pretFPS ;
       wikibase:grammaticalFeature wd:Q442485, wd:Q51929218 .
-  } 
+  }
 
   # SPS
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pretSPSForm .
     ?pretSPSForm ontolex:representation ?pretSPS ;
       wikibase:grammaticalFeature wd:Q442485, wd:Q51929369 .
-  } 
+  }
 
   # TPS
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pretTPSForm .
     ?pretTPSForm ontolex:representation ?pretTPS ;
       wikibase:grammaticalFeature wd:Q442485, wd:Q51929447 .
-  } 
+  }
 
   # FPP
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pretFPPForm .
     ?pretFPPForm ontolex:representation ?pretFPP ;
       wikibase:grammaticalFeature wd:Q442485, wd:Q51929290 .
-  } 
+  }
 
   # SPP
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pretSPPForm .
     ?pretSPPForm ontolex:representation ?pretSPP ;
       wikibase:grammaticalFeature wd:Q442485, wd:Q51929403 .
-  } 
+  }
 
   # TPP
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pretTPPForm .
     ?pretTPPForm ontolex:representation ?pretTPP ;
       wikibase:grammaticalFeature wd:Q442485, wd:Q51929517 .
-  } 
+  }
 }

--- a/src/scribe_data/language_data_extraction/Italian/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/language_data_extraction/Italian/verbs/query_verbs_2.sparql
@@ -19,41 +19,53 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?impFPSForm .
     ?impFPSForm ontolex:representation ?impFPS ;
-      wikibase:grammaticalFeature wd:Q12547192, wd:Q51929218 ;
+      wikibase:grammaticalFeature wd:Q12547192 ;
+      wikibase:grammaticalFeature wd:Q21714344 ;
+      wikibase:grammaticalFeature wd:Q110786 ;
   } .
 
   # SPS
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?impSPSForm .
     ?impSPSForm ontolex:representation ?impSPS ;
-      wikibase:grammaticalFeature wd:Q12547192, wd:Q51929369 ;
+      wikibase:grammaticalFeature wd:Q12547192 ;
+      wikibase:grammaticalFeature wd:Q51929049 ;
+      wikibase:grammaticalFeature wd:Q110786 ;
   } .
 
   # TPS
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?impTPSForm .
     ?impTPSForm ontolex:representation ?impTPS ;
-      wikibase:grammaticalFeature wd:Q12547192, wd:Q51929447 ;
+      wikibase:grammaticalFeature wd:Q12547192 ;
+      wikibase:grammaticalFeature wd:Q51929074 ;
+      wikibase:grammaticalFeature wd:Q110786 ;
   } .
 
   # FPP
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?impFPPForm .
     ?impFPPForm ontolex:representation ?impFPP ;
-      wikibase:grammaticalFeature wd:Q12547192, wd:Q51929290 ;
+      wikibase:grammaticalFeature wd:Q12547192 ;
+      wikibase:grammaticalFeature wd:Q21714344 ;
+      wikibase:grammaticalFeature wd:Q146786 ;
   } .
 
   # SPP
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?impSPPForm .
     ?impSPPForm ontolex:representation ?impSPP ;
-      wikibase:grammaticalFeature wd:Q12547192, wd:Q51929403 ;
+      wikibase:grammaticalFeature wd:Q12547192 ;
+      wikibase:grammaticalFeature wd:Q51929049 ;
+      wikibase:grammaticalFeature wd:Q146786 ;
   } .
 
   # TPP
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?impTPPForm .
     ?impTPPForm ontolex:representation ?impTPP ;
-      wikibase:grammaticalFeature wd:Q12547192, wd:Q51929517 ;
+      wikibase:grammaticalFeature wd:Q12547192 ;
+      wikibase:grammaticalFeature wd:Q51929074 ;
+      wikibase:grammaticalFeature wd:Q146786 ;
   } .
 }

--- a/src/scribe_data/language_data_extraction/Italian/verbs/query_verbs_3.sparql
+++ b/src/scribe_data/language_data_extraction/Italian/verbs/query_verbs_3.sparql
@@ -20,53 +20,41 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pretFPSForm .
     ?pretFPSForm ontolex:representation ?pretFPS ;
-      wikibase:grammaticalFeature wd:Q442485 ;
-      wikibase:grammaticalFeature wd:Q21714344 ;
-      wikibase:grammaticalFeature wd:Q110786 ;
-  } .
+      wikibase:grammaticalFeature wd:Q442485, wd:Q21714344, wd:Q110786 .
+  }
 
   # SPS
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pretSPSForm .
     ?pretSPSForm ontolex:representation ?pretSPS ;
-      wikibase:grammaticalFeature wd:Q442485 ;
-      wikibase:grammaticalFeature wd:Q51929049 ;
-      wikibase:grammaticalFeature wd:Q110786 ;
-  } .
+      wikibase:grammaticalFeature wd:Q442485, wd:Q51929049, wd:Q110786 .
+  }
 
   # TPS
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pretTPSForm .
     ?pretTPSForm ontolex:representation ?pretTPS ;
-      wikibase:grammaticalFeature wd:Q442485 ;
-      wikibase:grammaticalFeature wd:Q51929074 ;
-      wikibase:grammaticalFeature wd:Q110786 ;
-  } .
+      wikibase:grammaticalFeature wd:Q442485, wd:Q51929074, wd:Q110786 .
+  }
 
   # FPP
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pretFPPForm .
     ?pretFPPForm ontolex:representation ?pretFPP ;
-      wikibase:grammaticalFeature wd:Q442485 ;
-      wikibase:grammaticalFeature wd:Q21714344 ;
-      wikibase:grammaticalFeature wd:Q146786 ;
-  } .
+      wikibase:grammaticalFeature wd:Q442485, wd:Q21714344, wd:Q146786 .
+  }
 
   # SPP
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pretSPPForm .
     ?pretSPPForm ontolex:representation ?pretSPP ;
-      wikibase:grammaticalFeature wd:Q442485 ;
-      wikibase:grammaticalFeature wd:Q51929049 ;
-      wikibase:grammaticalFeature wd:Q146786 ;
-  } .
+      wikibase:grammaticalFeature wd:Q442485, wd:Q51929049, wd:Q146786 .
+  }
 
   # TPP
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pretTPPForm .
     ?pretTPPForm ontolex:representation ?pretTPP ;
-      wikibase:grammaticalFeature wd:Q442485 ;
-      wikibase:grammaticalFeature wd:Q51929074 ;
-      wikibase:grammaticalFeature wd:Q146786 ;
-  } .
+      wikibase:grammaticalFeature wd:Q442485, wd:Q51929074, wd:Q146786 .
+  }
 }

--- a/src/scribe_data/language_data_extraction/Italian/verbs/query_verbs_3.sparql
+++ b/src/scribe_data/language_data_extraction/Italian/verbs/query_verbs_3.sparql
@@ -1,3 +1,4 @@
+
 # tool: scribe-data
 # All Italian (Q652) verbs and the currently implemented tenses for each.
 # Enter this query at https://query.wikidata.org/.
@@ -5,67 +6,66 @@
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?infinitive
-  ?presFPS ?presSPS ?presTPS
-  ?presFPP ?presSPP ?presTPP
-
+  ?pretFPS ?pretSPS ?pretTPS
+  ?pretFPP ?pretSPP ?pretTPP
 
 WHERE {
   ?lexeme dct:language wd:Q652 ;
     wikibase:lexicalCategory wd:Q24905 ;
     wikibase:lemma ?infinitive .
 
-  # MARK: Present
+  # MARK: Preterite
 
   # FPS
   OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?presFPSForm .
-    ?presFPSForm ontolex:representation ?presFPS ;
-      wikibase:grammaticalFeature wd:Q56682909 ;
+    ?lexeme ontolex:lexicalForm ?pretFPSForm .
+    ?pretFPSForm ontolex:representation ?pretFPS ;
+      wikibase:grammaticalFeature wd:Q442485 ;
       wikibase:grammaticalFeature wd:Q21714344 ;
       wikibase:grammaticalFeature wd:Q110786 ;
   } .
 
   # SPS
   OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?presSPSForm .
-    ?presSPSForm ontolex:representation ?presSPS ;
-      wikibase:grammaticalFeature wd:Q56682909 ;
+    ?lexeme ontolex:lexicalForm ?pretSPSForm .
+    ?pretSPSForm ontolex:representation ?pretSPS ;
+      wikibase:grammaticalFeature wd:Q442485 ;
       wikibase:grammaticalFeature wd:Q51929049 ;
       wikibase:grammaticalFeature wd:Q110786 ;
   } .
 
   # TPS
   OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?presTPSForm .
-    ?presTPSForm ontolex:representation ?presTPS ;
-      wikibase:grammaticalFeature wd:Q56682909 ;
+    ?lexeme ontolex:lexicalForm ?pretTPSForm .
+    ?pretTPSForm ontolex:representation ?pretTPS ;
+      wikibase:grammaticalFeature wd:Q442485 ;
       wikibase:grammaticalFeature wd:Q51929074 ;
       wikibase:grammaticalFeature wd:Q110786 ;
   } .
 
   # FPP
   OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?presFPPForm .
-    ?presFPPForm ontolex:representation ?presFPP ;
-      wikibase:grammaticalFeature wd:Q56682909 ;
+    ?lexeme ontolex:lexicalForm ?pretFPPForm .
+    ?pretFPPForm ontolex:representation ?pretFPP ;
+      wikibase:grammaticalFeature wd:Q442485 ;
       wikibase:grammaticalFeature wd:Q21714344 ;
       wikibase:grammaticalFeature wd:Q146786 ;
   } .
 
   # SPP
   OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?presSPPForm .
-    ?presSPPForm ontolex:representation ?presSPP ;
-      wikibase:grammaticalFeature wd:Q56682909 ;
+    ?lexeme ontolex:lexicalForm ?pretSPPForm .
+    ?pretSPPForm ontolex:representation ?pretSPP ;
+      wikibase:grammaticalFeature wd:Q442485 ;
       wikibase:grammaticalFeature wd:Q51929049 ;
       wikibase:grammaticalFeature wd:Q146786 ;
   } .
 
   # TPP
   OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?presTPPForm .
-    ?presTPPForm ontolex:representation ?presTPP ;
-      wikibase:grammaticalFeature wd:Q56682909 ;
+    ?lexeme ontolex:lexicalForm ?pretTPPForm .
+    ?pretTPPForm ontolex:representation ?pretTPP ;
+      wikibase:grammaticalFeature wd:Q442485 ;
       wikibase:grammaticalFeature wd:Q51929074 ;
       wikibase:grammaticalFeature wd:Q146786 ;
   } .


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
These changes expanded the Italian verb queries to use the new standard format of separate grammatical number (e.g singular) and grammatical person (e.g first person) instead of being combined (e.g first-person-singular) as was the case before.
The verb forms that are being retrieved include:
- Present Tense: First Person, Second Person and Third Person forms
- Preterite: First Person, Second Person and Third Person forms
- Imperfect: First Person, Second Person and Third Person forms

Additional file was created to separate the queries to prevent timeout errors.

The queries have been tested on [Wikidata Query Service UI](https://query.wikidata.org/) and the outputs are without errors.
### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #273
