### PR TITLE
Greek adverbs and adjectives

### DIFF
--- a/src/scribe_data/language_data_extraction/Greek/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/language_data_extraction/Greek/adjectives/query_adjectives.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Greek (Q36510) adjectives.
+# All Greek (Q36510) adjectives and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT
@@ -10,5 +10,4 @@ WHERE {
   ?lexeme dct:language wd:Q36510 ;
     wikibase:lexicalCategory wd:Q34698 ;
     wikibase:lemma ?adjective .
-
 }

--- a/src/scribe_data/language_data_extraction/Greek/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/language_data_extraction/Greek/adjectives/query_adjectives.sparql
@@ -1,0 +1,14 @@
+# tool: scribe-data
+# All Greek (Q36510) adjectives.
+# Enter this query at https://query.wikidata.org/.
+
+SELECT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
+  ?adjective
+
+WHERE {
+  ?lexeme dct:language wd:Q36510 ;
+    wikibase:lexicalCategory wd:Q34698 ;
+    wikibase:lemma ?adjective .
+
+}

--- a/src/scribe_data/language_data_extraction/Greek/adverbs/query_adverbs.sparql
+++ b/src/scribe_data/language_data_extraction/Greek/adverbs/query_adverbs.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Greek (Q36510) adverbs.
+# All Greek (Q36510) adverbs and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT
@@ -10,5 +10,4 @@ WHERE {
   ?lexeme dct:language wd:Q36510 ;
     wikibase:lexicalCategory wd:Q380057 ;
     wikibase:lemma ?adverb .
-
 }

--- a/src/scribe_data/language_data_extraction/Greek/adverbs/query_adverbs.sparql
+++ b/src/scribe_data/language_data_extraction/Greek/adverbs/query_adverbs.sparql
@@ -4,11 +4,11 @@
 
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
-  ?adjective
+  ?adverb
 
 WHERE {
   ?lexeme dct:language wd:Q36510 ;
     wikibase:lexicalCategory wd:Q380057 ;
-    wikibase:lemma ?adjective .
+    wikibase:lemma ?adverb .
 
 }

--- a/src/scribe_data/language_data_extraction/Greek/adverbs/query_adverbs.sparql
+++ b/src/scribe_data/language_data_extraction/Greek/adverbs/query_adverbs.sparql
@@ -1,0 +1,14 @@
+# tool: scribe-data
+# All Greek (Q36510) adverbs.
+# Enter this query at https://query.wikidata.org/.
+
+SELECT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
+  ?adjective
+
+WHERE {
+  ?lexeme dct:language wd:Q36510 ;
+    wikibase:lexicalCategory wd:Q380057 ;
+    wikibase:lemma ?adjective .
+
+}


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

This PR adds two files to extract Greek adverbs and adjectives using SPARQL. Currently, the Greek directory supports extracting nouns, verbs, and now adverbs and adjectives.
