### PR TITLE
building the docs based on the modules in requirements.txt

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,7 +36,6 @@ release = "3.3.0"
 # ones.
 extensions = [
     # "m2r2",
-    "recommonmark",
     "sphinx.ext.autodoc",
     "numpydoc",
     "sphinx.ext.viewcode",
@@ -78,11 +77,8 @@ exclude_patterns = []
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-# source_suffix = ".rst"
-source_suffix = {
-    ".rst": "restructuredtext",
-    ".md": "markdown",
-}
+source_suffix = ".rst"
+
 
 # The master toctree document.
 master_doc = "index"
@@ -96,7 +92,7 @@ pygments_style = "sphinx"
 html_theme = "sphinx_rtd_theme"
 
 # html_theme_path = [sphinx_rtd_theme]
-html_theme_path = []
+# html_theme_path = []
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -184,7 +180,7 @@ texinfo_documents = [
 html_logo = "_static/ScribeDataLogo.png"
 html_theme_options = {
     "logo_only": True,
-    # "display_version": True,
+    "display_version": True,
 }
 
 # Adding favicon to the docs.


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description
- Ensured compatibility with req.txt modules.
- Adjusted the documentation build process to successfully generate the HTML output without significant warnings or errors.
![a](https://github.com/user-attachments/assets/cda29371-a0a3-469b-a36d-6778479b9949)

**Testing:**
- The build was tested using the git bash command `python -m sphinx -T -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html`, resulting in a successful build with no warnings. 


### Related issue

- #382 
