### PR TITLE
Russian adjectives and their common forms

### DIFF
--- a/src/scribe_data/language_data_extraction/Russian/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/language_data_extraction/Russian/adjectives/query_adjectives.sparql
@@ -31,6 +31,10 @@ SELECT
   ?prepositionalPlural
   ?inanimateAccusativeSingular
   ?inanimateAccusativePlural
+  ?masculineShortFormSingular
+  ?neuterShortFormSingular
+  ?feminineShortFormSingular
+  ?ShortFormplural
 WHERE {
   ?lexeme dct:language wd:Q7737 ;
     wikibase:lexicalCategory wd:Q34698 ;
@@ -202,5 +206,30 @@ WHERE {
     ?lexeme ontolex:lexicalForm ?prepositionalPluralForm .
     ?prepositionalPluralForm ontolex:representation ?prepositionalPlural ;
       wikibase:grammaticalFeature wd:Q2114906, wd:Q146786  .
+  }
+  # MARK: Short Form
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?masculineShortFormSingularForm .
+    ?masculineShortFormSingularForm ontolex:representation ?masculineShortFormSingular ;
+      wikibase:grammaticalFeature wd:Q499327, wd:Q4239848, wd:Q110786 .
+  }
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?neuterShortFormSingularForm .
+    ?neuterShortFormSingularForm ontolex:representation ?neuterShortFormSingular ;
+      wikibase:grammaticalFeature wd:Q1775461, wd:Q4239848, wd:Q110786 .
+  }
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?feminineShortFormSingularForm .
+    ?feminineShortFormSingularForm ontolex:representation ?feminineShortFormSingular ;
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q4239848, wd:Q110786 .
+  }
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?ShortFormpluralForm .
+    ?ShortFormpluralForm ontolex:representation ?ShortFormplural ;
+      wikibase:grammaticalFeature wd:Q4239848, wd:Q146786 .
   }
 }

--- a/src/scribe_data/language_data_extraction/Russian/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/language_data_extraction/Russian/adjectives/query_adjectives.sparql
@@ -9,19 +9,34 @@ SELECT
   ?neuterNominativeSingular
   ?feminineNominativeSingular
   ?nominativePlural
+  ?masculineGenitiveSingular
+  ?neuterGenitiveSingular
+  ?feminineGenitiveSingular
   ?genitivePlural
+  ?masculineDativeSingular
+  ?neuterDativeSingular
+  ?feminineDativeSingular
   ?dativePlural
+  ?masculineAnimateAccusativeSingular
+  ?neuterAnimateAccusativeSingular
+  ?feminineAnimateAccusativeSingular
   ?animateAccusativePlural
-  ?inanimateAccusativePlural
+  ?masculineInstrumentalSingular
+  ?neuterInstrumentalSingular
+  ?feminineInstrumentalSingular
+  ?instrumentalPlural
+  ?masculinePrepositionalSingular
+  ?neuterPrepositionalSingular
   ?femininePrepositionalSingular
   ?prepositionalPlural
-
+  ?inanimateAccusativeSingular
+  ?inanimateAccusativePlural
 WHERE {
   ?lexeme dct:language wd:Q7737 ;
     wikibase:lexicalCategory wd:Q34698 ;
     wikibase:lemma ?adjective .
 
-  # MARK: Nominative
+  # MARK: Nominative Forms
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineNominativeSingularForm .
@@ -47,7 +62,25 @@ WHERE {
       wikibase:grammaticalFeature wd:Q131105, wd:Q146786 .
   }
 
-  # MARK: Genitive, Plural
+  # MARK: Genitive Forms
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?masculineGenitiveSingularForm .
+    ?masculineGenitiveSingularForm ontolex:representation ?masculineGenitiveSingular ;
+      wikibase:grammaticalFeature wd:Q499327, wd:Q146233, wd:Q110786 .
+  }
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?neuterGenitiveSingularForm .
+    ?neuterGenitiveSingularForm ontolex:representation ?neuterGenitiveSingular ;
+      wikibase:grammaticalFeature wd:Q1775461, wd:Q146233, wd:Q110786 .
+  }
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?feminineGenitiveSingularForm .
+    ?feminineGenitiveSingularForm ontolex:representation ?feminineGenitiveSingular ;
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q146233, wd:Q110786 .
+  }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitivePluralForm .
@@ -55,7 +88,25 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146233, wd:Q146786 .
   }
 
-  # MARK: Dative Case, Plural
+  # MARK: Dative Forms
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?masculineDativeSingularForm .
+    ?masculineDativeSingularForm ontolex:representation ?masculineDativeSingular ;
+      wikibase:grammaticalFeature wd:Q499327, wd:Q145599, wd:Q110786 .
+  }
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?neuterDativeSingularForm .
+    ?neuterDativeSingularForm ontolex:representation ?neuterDativeSingular ;
+      wikibase:grammaticalFeature wd:Q1775461, wd:Q145599, wd:Q110786 .
+  }
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?feminineDativeSingularForm .
+    ?feminineDativeSingularForm ontolex:representation ?feminineDativeSingular ;
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q145599, wd:Q110786 .
+  }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?dativePluralForm .
@@ -63,7 +114,25 @@ WHERE {
       wikibase:grammaticalFeature wd:Q145599, wd:Q146786 .
   }
 
-  # MARK: Animate, Accusative, Plural
+  # MARK: Accusative Forms
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?masculineAnimateAccusativeSingularForm .
+    ?masculineAnimateAccusativeSingularForm ontolex:representation ?masculineAnimateAccusativeSingular ;
+      wikibase:grammaticalFeature wd:Q499327,wd:Q51927507, wd:Q146078, wd:Q110786 .
+  }
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?neuterAnimateAccusativeSingularForm .
+    ?neuterAnimateAccusativeSingularForm ontolex:representation ?neuterAnimateAccusativeSingular ;
+      wikibase:grammaticalFeature wd:Q1775461,wd:Q51927507, wd:Q146078, wd:Q110786 .
+  }
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?feminineAnimateAccusativeSingularForm .
+    ?feminineAnimateAccusativeSingularForm ontolex:representation ?feminineAnimateAccusativeSingular ;
+      wikibase:grammaticalFeature wd:Q1775415,wd:Q51927507 ,wd:Q146078, wd:Q110786 .
+  }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?animateAccusativePluralForm .
@@ -71,7 +140,11 @@ WHERE {
       wikibase:grammaticalFeature wd:Q51927507, wd:Q146078, wd:Q146786 .
   }
 
-  # MARK: Inanimate, Accusative, Plural
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?inanimateAccusativeSingularForm .
+    ?inanimateAccusativeSingularForm ontolex:representation ?inanimateAccusativeSingular ;
+      wikibase:grammaticalFeature wd:Q51927539, wd:Q146078, wd:Q110786 .
+  }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?inanimateAccusativePluralForm .
@@ -79,19 +152,55 @@ WHERE {
       wikibase:grammaticalFeature wd:Q51927539, wd:Q146078, wd:Q146786 .
   }
 
-  # MARK: Prepositional, Singular
+  # MARK: Instrumental Forms
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?masculineInstrumentalSingularForm .
+    ?masculineInstrumentalSingularForm ontolex:representation ?masculineInstrumentalSingular ;
+      wikibase:grammaticalFeature wd:Q499327, wd:Q192997, wd:Q110786 .
+  }
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?neuterInstrumentalSingularForm .
+    ?neuterInstrumentalSingularForm ontolex:representation ?neuterInstrumentalSingular ;
+      wikibase:grammaticalFeature wd:Q1775461, wd:Q192997, wd:Q110786 .
+  }
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?feminineInstrumentalSingularForm .
+    ?feminineInstrumentalSingularForm ontolex:representation ?feminineInstrumentalSingular ;
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q192997, wd:Q110786 .
+  }
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?instrumentalPluralForm .
+    ?instrumentalPluralForm ontolex:representation ?instrumentalPlural ;
+      wikibase:grammaticalFeature wd:Q192997, wd:Q146786 .
+  }
+
+  # MARK: Prepositional Forms
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?masculinePrepositionalSingularForm .
+    ?masculinePrepositionalSingularForm ontolex:representation ?masculinePrepositionalSingular ;
+      wikibase:grammaticalFeature wd:Q499327, wd:Q2114906, wd:Q110786  .
+  }
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?neuterPrepositionalSingularForm .
+    ?neuterPrepositionalSingularForm ontolex:representation ?neuterPrepositionalSingular ;
+      wikibase:grammaticalFeature wd:Q1775461, wd:Q2114906, wd:Q110786  .
+  }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?femininePrepositionalSingularForm .
     ?femininePrepositionalSingularForm ontolex:representation ?femininePrepositionalSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q2114906, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q2114906, wd:Q110786  .
   }
-
-  # MARK: Prepositional, Plural
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?prepositionalPluralForm .
     ?prepositionalPluralForm ontolex:representation ?prepositionalPlural ;
-      wikibase:grammaticalFeature wd:Q2114906, wd:Q146786 .
+      wikibase:grammaticalFeature wd:Q2114906, wd:Q146786  .
   }
 }

--- a/src/scribe_data/language_data_extraction/Russian/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/language_data_extraction/Russian/adjectives/query_adjectives.sparql
@@ -31,16 +31,17 @@ SELECT
   ?prepositionalPlural
   ?inanimateAccusativeSingular
   ?inanimateAccusativePlural
-  ?masculineShortFormSingular
-  ?neuterShortFormSingular
-  ?feminineShortFormSingular
-  ?ShortFormplural
+  ?masculineShortSingular
+  ?neuterShortSingular
+  ?feminineShortSingular
+  ?pluralShort
+
 WHERE {
   ?lexeme dct:language wd:Q7737 ;
     wikibase:lexicalCategory wd:Q34698 ;
     wikibase:lemma ?adjective .
 
-  # MARK: Nominative Forms
+  # MARK: Nominative
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineNominativeSingularForm .
@@ -66,7 +67,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q131105, wd:Q146786 .
   }
 
-  # MARK: Genitive Forms
+  # MARK: Genitive
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineGenitiveSingularForm .
@@ -92,7 +93,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q146233, wd:Q146786 .
   }
 
-  # MARK: Dative Forms
+  # MARK: Dative
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineDativeSingularForm .
@@ -118,7 +119,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q145599, wd:Q146786 .
   }
 
-  # MARK: Accusative Forms
+  # MARK: Accusative
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineAnimateAccusativeSingularForm .
@@ -156,7 +157,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q51927539, wd:Q146078, wd:Q146786 .
   }
 
-  # MARK: Instrumental Forms
+  # MARK: Instrumental
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineInstrumentalSingularForm .
@@ -182,7 +183,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q192997, wd:Q146786 .
   }
 
-  # MARK: Prepositional Forms
+  # MARK: Prepositional
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculinePrepositionalSingularForm .
@@ -207,29 +208,30 @@ WHERE {
     ?prepositionalPluralForm ontolex:representation ?prepositionalPlural ;
       wikibase:grammaticalFeature wd:Q2114906, wd:Q146786  .
   }
-  # MARK: Short Form
+
+  # MARK: Short
 
   OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?masculineShortFormSingularForm .
-    ?masculineShortFormSingularForm ontolex:representation ?masculineShortFormSingular ;
+    ?lexeme ontolex:lexicalForm ?masculineShortSingularForm .
+    ?masculineShortSingularForm ontolex:representation ?masculineShortSingular ;
       wikibase:grammaticalFeature wd:Q499327, wd:Q4239848, wd:Q110786 .
   }
 
   OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?neuterShortFormSingularForm .
-    ?neuterShortFormSingularForm ontolex:representation ?neuterShortFormSingular ;
+    ?lexeme ontolex:lexicalForm ?neuterShortSingularForm .
+    ?neuterShortSingularForm ontolex:representation ?neuterShortSingular ;
       wikibase:grammaticalFeature wd:Q1775461, wd:Q4239848, wd:Q110786 .
   }
 
   OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?feminineShortFormSingularForm .
-    ?feminineShortFormSingularForm ontolex:representation ?feminineShortFormSingular ;
+    ?lexeme ontolex:lexicalForm ?feminineShortSingularForm .
+    ?feminineShortSingularForm ontolex:representation ?feminineShortSingular ;
       wikibase:grammaticalFeature wd:Q1775415, wd:Q4239848, wd:Q110786 .
   }
 
   OPTIONAL {
-    ?lexeme ontolex:lexicalForm ?ShortFormpluralForm .
-    ?ShortFormpluralForm ontolex:representation ?ShortFormplural ;
+    ?lexeme ontolex:lexicalForm ?pluralShortForm .
+    ?pluralShortForm ontolex:representation ?pluralShort ;
       wikibase:grammaticalFeature wd:Q4239848, wd:Q146786 .
   }
 }

--- a/src/scribe_data/language_data_extraction/Russian/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/language_data_extraction/Russian/adjectives/query_adjectives.sparql
@@ -1,0 +1,97 @@
+# tool: scribe-data
+# All Russian (Q7737) adjectives (Q34698) and the given forms.
+# Enter this query at https://query.wikidata.org/.
+
+SELECT
+  (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
+  ?adjective
+  ?masculineNominativeSingular
+  ?neuterNominativeSingular
+  ?feminineNominativeSingular
+  ?nominativePlural
+  ?genitivePlural
+  ?dativePlural
+  ?animateAccusativePlural
+  ?inanimateAccusativePlural
+  ?femininePrepositionalSingular
+  ?prepositionalPlural
+
+WHERE {
+  ?lexeme dct:language wd:Q7737 ;
+    wikibase:lexicalCategory wd:Q34698 ;
+    wikibase:lemma ?adjective .
+
+  # MARK: Nominative
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?masculineNominativeSingularForm .
+    ?masculineNominativeSingularForm ontolex:representation ?masculineNominativeSingular ;
+      wikibase:grammaticalFeature wd:Q499327, wd:Q131105, wd:Q110786 .
+  }
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?neuterNominativeSingularForm .
+    ?neuterNominativeSingularForm ontolex:representation ?neuterNominativeSingular ;
+      wikibase:grammaticalFeature wd:Q1775461, wd:Q131105, wd:Q110786 .
+  }
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?feminineNominativeSingularForm .
+    ?feminineNominativeSingularForm ontolex:representation ?feminineNominativeSingular ;
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q131105, wd:Q110786 .
+  }
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?nominativePluralForm .
+    ?nominativePluralForm ontolex:representation ?nominativePlural ;
+      wikibase:grammaticalFeature wd:Q131105, wd:Q146786 .
+  }
+
+  # MARK: Genitive, Plural
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?genitivePluralForm .
+    ?genitivePluralForm ontolex:representation ?genitivePlural ;
+      wikibase:grammaticalFeature wd:Q146233, wd:Q146786 .
+  }
+
+  # MARK: Dative Case, Plural
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?dativePluralForm .
+    ?dativePluralForm ontolex:representation ?dativePlural ;
+      wikibase:grammaticalFeature wd:Q145599, wd:Q146786 .
+  }
+
+  # MARK: Animate, Accusative, Plural
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?animateAccusativePluralForm .
+    ?animateAccusativePluralForm ontolex:representation ?animateAccusativePlural ;
+      wikibase:grammaticalFeature wd:Q51927507, wd:Q146078, wd:Q146786 .
+  }
+
+  # MARK: Inanimate, Accusative, Plural
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?inanimateAccusativePluralForm .
+    ?inanimateAccusativePluralForm ontolex:representation ?inanimateAccusativePlural ;
+      wikibase:grammaticalFeature wd:Q51927539, wd:Q146078, wd:Q146786 .
+  }
+
+  # MARK: Prepositional, Singular
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?femininePrepositionalSingularForm .
+    ?femininePrepositionalSingularForm ontolex:representation ?femininePrepositionalSingular ;
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q2114906, wd:Q110786 .
+  }
+
+  # MARK: Prepositional, Plural
+
+  OPTIONAL {
+    ?lexeme ontolex:lexicalForm ?prepositionalPluralForm .
+    ?prepositionalPluralForm ontolex:representation ?prepositionalPlural ;
+      wikibase:grammaticalFeature wd:Q2114906, wd:Q146786 .
+  }
+}


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

This PR adds a SPARQL file to extract Russian adjectives. Currently, the Russian directory supports extracting nouns, verbs, adverbs, prepositions, emoji_keywords and now and adjectives.
