### PR TITLE
Lowercase CLI args on first parse in `main.py`

### DIFF
--- a/src/scribe_data/cli/main.py
+++ b/src/scribe_data/cli/main.py
@@ -202,6 +202,11 @@ def main() -> None:
 
     args = parser.parse_args()
 
+    # Lowercase all args on first parse
+    args.language = args.language.lower() if args.language else None
+    args.data_type = args.data_type.lower() if args.data_type else None
+    args.output_type = args.output_type.lower() if args.output_type else None
+
     try:
         if args.language or args.data_type:
             validate_language_and_data_type(


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

This PR introduces two key changes to the Scribe-Data CLI:

- **Lowercasing Arguments on First Parse**:
   All language, data-type, and output-type arguments passed to the CLI are now lowercased immediately after parsing. This ensures consistency and avoids case-related errors when processing commands.

   **Changes:**
   - The arguments `language`, `data_type`, and `output_type` are now lowercased as soon as they are parsed using `parser.parse_args()`. This is done through:
     ```python
     args.language = args.language.lower() if args.language else None
     args.data_type = args.data_type.lower() if args.data_type else None
     args.output_type = args.output_type.lower() if args.output_type else None
     ```
   **Changes:**
   - Comments and references in logic have been updated accordingly, ensuring all paths related to language data extraction now point to the new `wikidata` directory.


**Next Steps:**
- Necessary documentation updates to reflect this new directory structure.

---


### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #446 
