### PR TITLE
List command formatting

### DIFF
--- a/docs/source/scribe_data/cli.rst
+++ b/docs/source/scribe_data/cli.rst
@@ -56,13 +56,12 @@ Example output:
     $ scribe-data list
 
     Language     ISO  QID
-    -----------------------
+    ==========================
     English      en   Q1860
     ...
-    -----------------------
 
     Available data types: All languages
-    -----------------------------------
+    ===================================
     adjectives
     adverbs
     emoji-keywords
@@ -72,7 +71,7 @@ Example output:
     prepositions
     proper-nouns
     verbs
-    -----------------------------------
+
 
 
 
@@ -81,10 +80,9 @@ Example output:
     $scribe-data list --language
 
     Language     ISO  QID
-    -----------------------
+    ==========================
     English      en   Q1860
     ...
-    -----------------------
 
 
 .. code-block:: text
@@ -92,7 +90,7 @@ Example output:
     $scribe-data list -dt
 
     Available data types: All languages
-    -----------------------------------
+    ===================================
     adjectives
     adverbs
     emoji-keywords
@@ -102,7 +100,6 @@ Example output:
     prepositions
     proper-nouns
     verbs
-    -----------------------------------
 
 
 .. code-block:: text
@@ -110,13 +107,12 @@ Example output:
     $scribe-data list -a
 
     Language     ISO  QID
-    -----------------------
+    ==========================
     English      en   Q1860
     ...
-    -----------------------
 
     Available data types: All languages
-    -----------------------------------
+    ===================================
     adjectives
     adverbs
     emoji-keywords
@@ -126,7 +122,6 @@ Example output:
     prepositions
     proper-nouns
     verbs
-    -----------------------------------
 
 Get Command
 ~~~~~~~~~~~

--- a/src/scribe_data/cli/list.py
+++ b/src/scribe_data/cli/list.py
@@ -51,14 +51,13 @@ def list_languages() -> None:
     print(
         f"{'Language':<{language_col_width}} {'ISO':<{iso_col_width}} {'QID':<{qid_col_width}}"
     )
-    print("-" * table_line_length)
+    print("=" * table_line_length)
 
     for lang in languages:
         print(
             f"{lang.capitalize():<{language_col_width}} {get_language_iso(lang):<{iso_col_width}} {get_language_qid(lang):<{qid_col_width}}"
         )
 
-    print("-" * table_line_length)
     print()
 
 
@@ -105,13 +104,12 @@ def list_data_types(language: str = None) -> None:
 
     print()
     print(table_header)
-    print("-" * table_line_length)
+    print("=" * table_line_length)
 
     data_types = sorted(data_types)
     for dt in data_types:
         print(dt.replace("_", "-"))
 
-    print("-" * table_line_length)
     print()
 
 
@@ -147,7 +145,7 @@ def list_languages_for_data_type(data_type: str) -> None:
     print(
         f"{'Language':<{language_col_width}} {'ISO':<{iso_col_width}} {'QID':<{qid_col_width}}"
     )
-    print("-" * table_line_length)
+    print("=" * table_line_length)
 
     # Iterate through the list of languages and format each row.
     for lang in all_languages:
@@ -155,7 +153,6 @@ def list_languages_for_data_type(data_type: str) -> None:
             f"{lang['name'].capitalize():<{language_col_width}} {lang['iso']:<{iso_col_width}} {lang['qid']:<{qid_col_width}}"
         )
 
-    print("-" * table_line_length)
     print()
 
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [ ] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description
- Replaced single-line separators with double-line separators for clearer distinction between headers and data.
- Removed the unnecessary line at the end of the table for a cleaner output.
- Updated the documentation to reflect the new formatting for `list` commands.

### Related issue
- This resolves the issue where the `list` command formatting differed from the `total` command.
- #466
