### PR TITLE
Check select where labels order

### DIFF
--- a/src/scribe_data/check/check_query_forms.py
+++ b/src/scribe_data/check/check_query_forms.py
@@ -436,7 +436,7 @@ def check_forms_order(query_text: str) -> bool:
     if select_match := re.search(select_pattern, query_text, flags=re.DOTALL):
         select_vars = re.findall(r"\?(\w+)", select_match.group(1))
     else:
-        return False  # Invalid query format if no SELECT match.
+        return False  # invalid query format if no SELECT match.
 
     # Exclude the first two variables from select_vars
     select_vars = select_vars[2:]
@@ -453,8 +453,8 @@ def check_forms_order(query_text: str) -> bool:
         where_vars.append(dt_match[0])
     where_vars += re.findall(forms_pattern, query_text)
 
-    # Handling specific variables like 'case' and 'gender' in the same order as in select_vars
-    for var in ["case", "gender"]:
+    # Handling labels provided by the labeling service  like 'case' and 'gender' in the same order as in select_vars
+    for var in ["case", "gender", "auxiliaryVerb"]:
         if var in select_vars:
             # Insert in the corresponding index of where_vars
             index = select_vars.index(var)
@@ -497,7 +497,7 @@ def check_query_forms() -> None:
             error_output += f"\n{index}. {query_file_str}: {defined_unreturned_forms}\n"
             index += 1
 
-        # Check the order of variables in the WHERE clause
+        # Check the order of variables in the WHERE and SELECT clauses.
         select_where_labels_matching = check_forms_order(query_text)
         if not select_where_labels_matching:
             error_output += f"\n{index}. {query_file_str}: The order of variables in the SELECT statement does not match the WHERE clause.\n"

--- a/src/scribe_data/check/check_query_forms.py
+++ b/src/scribe_data/check/check_query_forms.py
@@ -410,7 +410,7 @@ def check_defined_return_forms(query_text: str) -> str:
     return ""
 
 
-# MARK: forms order within the query
+# MARK: Forms Order
 
 
 def check_forms_order(query_text: str) -> bool:
@@ -420,47 +420,48 @@ def check_forms_order(query_text: str) -> bool:
 
     Parameters
     ----------
-    query_file : str
-        The SPARQL query text as a string.
+        query_file : str
+            The SPARQL query text as a string.
 
     Returns
     -------
-    bool
-        True if the order of the matches, False otherwise.
+        bool
+            True if the order of the matches, False otherwise.
     """
-
-    # Regex pattern to capture the variables in the SELECT statement.
     select_pattern = r"SELECT\s+(.*?)\s+WHERE"
 
     # Extracting the variables from the SELECT statement.
     if select_match := re.search(select_pattern, query_text, flags=re.DOTALL):
-        select_vars = re.findall(r"\?(\w+)", select_match.group(1))
-    else:
-        return False  # invalid query format if no SELECT match.
+        select_vars = re.findall(r"\?(\w+)", select_match[1])
 
-    # Exclude the first two variables from select_vars
+    else:
+        return False  # invalid query format if no SELECT match
+
+    # Exclude the first two variables from select_vars.
     select_vars = select_vars[2:]
     # Regex pattern to capture the variables in the WHERE clause.
     dt_pattern = r"WHERE\s*\{[^}]*?wikibase:lemma\s*\?\s*(\w+)\s*[;.]\s*"
     forms_pattern = r"ontolex:representation \?([^ ;]+)"
     where_vars = []
 
-    # Extracting variables from the WHERE clause
+    # Extracting variables from the WHERE clause.
     dt_match = re.findall(dt_pattern, query_text)
     if dt_match == ["lemma"]:
         where_vars.append("preposition")
+
     elif dt_match:
         where_vars.append(dt_match[0])
+
     where_vars += re.findall(forms_pattern, query_text)
 
-    # Handling labels provided by the labeling service  like 'case' and 'gender' in the same order as in select_vars
+    # Handling labels provided by the labeling service  like 'case' and 'gender' in the same order as in select_vars.
     for var in ["case", "gender", "auxiliaryVerb"]:
         if var in select_vars:
-            # Insert in the corresponding index of where_vars
+            # Insert in the corresponding index of where_vars.
             index = select_vars.index(var)
             where_vars.insert(index, var)
 
-    # Check if the order of variables matches
+    # Check if the order of variables matches.
     return select_vars == where_vars
 
 
@@ -500,7 +501,7 @@ def check_query_forms() -> None:
         # Check the order of variables in the WHERE and SELECT clauses.
         select_where_labels_matching = check_forms_order(query_text)
         if not select_where_labels_matching:
-            error_output += f"\n{index}. {query_file_str}: The order of variables in the SELECT statement does not match the WHERE clause.\n"
+            error_output += f"\n{index}. {query_file_str}:\n  - The order of variables in the SELECT statement does not match their order in the query.\n"
             index += 1
 
         if extract_forms_from_sparql(query_file):

--- a/src/scribe_data/wikidata/language_data_extraction/danish/verbs/query_verbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/danish/verbs/query_verbs.sparql
@@ -20,7 +20,7 @@ WHERE {
 
   ?lexeme dct:language wd:Q9035 ;
     wikibase:lexicalCategory wd:Q24905 ;
-    wikibase:lemma ?infinitive
+    wikibase:lemma ?infinitive .
 
   # MARK: Infinitive Active
 

--- a/src/scribe_data/wikidata/language_data_extraction/estonian/adjectives/query_adjectives_3.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/estonian/adjectives/query_adjectives_3.sparql
@@ -4,6 +4,7 @@
 
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
+  ?adjective
   ?adessiveSingular
   ?adessivePlural
   ?ablativeSingular

--- a/src/scribe_data/wikidata/language_data_extraction/estonian/adjectives/query_adjectives_4.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/estonian/adjectives/query_adjectives_4.sparql
@@ -4,6 +4,7 @@
 
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
+  ?adjective
   ?essiveSingular
   ?essivePlural
   ?abessiveSingular

--- a/src/scribe_data/wikidata/language_data_extraction/hebrew/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hebrew/verbs/query_verbs_2.sparql
@@ -4,7 +4,6 @@
 
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
-  ?infinitive
   ?feminineImperativeSecondPersonSingular
   ?masculineImperativeSecondPersonSingular
   ?feminineImperativeSecondPersonPlural

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/postpositions/query_postpositions.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/postpositions/query_postpositions.sparql
@@ -5,7 +5,6 @@
 # Note: We need to filter for "hi" to remove Urdu (ur) words.
 
 SELECT
-  ?lexeme
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?postposition
 

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/prepositions/query_prepositions.sparql
@@ -5,7 +5,6 @@
 # Note: We need to filter for "hi" to remove Urdu (ur) words.
 
 SELECT
-  ?lexeme
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?preposition
 

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/postpositions/query_postpositions.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/postpositions/query_postpositions.sparql
@@ -5,7 +5,6 @@
 # Note: We need to filter for "ur" to remove Hindi (hi) words.
 
 SELECT
-  ?lexeme
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?postposition
 

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/prepositions/query_prepositions.sparql
@@ -5,7 +5,6 @@
 # Note: We need to filter for "ur" to remove Hindi (hi) words.
 
 SELECT
-  ?lexeme
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?preposition
 

--- a/src/scribe_data/wikidata/language_data_extraction/italian/proper_nouns/query_proper_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/italian/proper_nouns/query_proper_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Italian (Q652) nouns (Q1084) and the given forms.
+# All Italian (Q652) proper nouns (Q147276) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/italian/proper_nouns/query_proper_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/italian/proper_nouns/query_proper_nouns.sparql
@@ -1,11 +1,10 @@
 # tool: scribe-data
-# All Italian (Q652) proper nouns (Q147276) and the given forms.
+# All Italian (Q652) nouns (Q1084) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?singular
-  ?plural
   ?gender
 
 WHERE {

--- a/src/scribe_data/wikidata/language_data_extraction/punjabi/shahmukhi/nouns/query_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/punjabi/shahmukhi/nouns/query_nouns.sparql
@@ -5,7 +5,6 @@
 # Note: We need to filter for "pnb" to select Shahmukhi words.
 
 SELECT
-  ?lexeme
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?singular
   ?plural

--- a/src/scribe_data/wikidata/language_data_extraction/punjabi/shahmukhi/proper_nouns/query_proper_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/punjabi/shahmukhi/proper_nouns/query_proper_nouns.sparql
@@ -5,7 +5,6 @@
 # Note: We need to filter for "pnb" to select Shahmukhi words.
 
 SELECT
-  ?lexeme
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?singular
   ?plural

--- a/src/scribe_data/wikidata/language_data_extraction/ukrainian/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/ukrainian/adjectives/query_adjectives.sparql
@@ -4,7 +4,7 @@
 
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
-  ?lemma
+  ?adjective
   ?nominativeFeminineSingular
   ?nominativeMasculineSingular
   ?nominativeNeuterSingular
@@ -15,7 +15,7 @@ SELECT
 WHERE {
   ?lexeme dct:language wd:Q8798 ;
     wikibase:lexicalCategory wd:Q34698 ;
-    wikibase:lemma ?lemma .
+    wikibase:lemma ?adjective .
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeFeminineSingularForm .


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description


**Added `check_forms_order` Function**  
   - Introduced a new function to validate the order of variables in the SELECT clause (excluding `lexeme` and `lexemeID`) against the order in the WHERE clause for SPARQL query files.
   - Implemented pattern matching to handle cases where variable forms are extracted from the WHERE clause.
   - Includes handling for label services providing additional data, ensuring consistency between SELECT and WHERE clause variable orders.



### Related issue


- #450 
