### PR TITLE
Implement check_docstring function for SPARQL docstring validation

### DIFF
--- a/src/scribe_data/check/check_query_forms.py
+++ b/src/scribe_data/check/check_query_forms.py
@@ -493,6 +493,45 @@ def check_forms_order(query_text: str) -> bool:
     return select_vars == where_vars
 
 
+# MARK: docstring Format
+
+
+def check_docstring(query_text: str) -> bool:
+    """
+    Checks the docstring of a SPARQL query text to ensure it follows the standard format.
+
+    Parameters
+    ----------
+    query_text : str
+        The SPARQL query's text to be checked.
+
+    Returns
+    -------
+    bool
+        True if the docstring is correctly formatted; otherwise, .
+    """
+    # Split the text into lines.
+    lines = query_text.splitlines(keepends=True)
+
+    # Regex patterns for each line in the docstring and corresponding error messages.
+    patterns = [
+        (r"^# tool: scribe-data\n", "Error in line 1:"),
+        (
+            r"^# All (.+?) \(Q\d+\) .+ \(Q\d+\) and the given forms\.\n",
+            "Error in line 2:",
+        ),
+        (
+            r"^# Enter this query at https://query\.wikidata\.org/\.\n",
+            "Error in line 3:",
+        ),
+    ]
+    # Check each line against its corresponding pattern.
+    for i, (pattern, error_line_number) in enumerate(patterns):
+        if not re.match(pattern, lines[i]):
+            return (False, f"{error_line_number} {lines[i].strip()}")
+    return True
+
+
 # MARK: Main Query Forms Validation
 def check_query_forms() -> None:
     """
@@ -505,6 +544,14 @@ def check_query_forms() -> None:
         query_file_str = str(query_file)
         with open(query_file, "r", encoding="utf-8") as file:
             query_text = file.read()
+
+        # Check the docstring format.
+        docstring_check_result = check_docstring(query_text)
+        if docstring_check_result is not True:
+            error_output += (
+                f"\n{index}. {query_file_str}:\n  - {docstring_check_result}\n"
+            )
+            index += 1
 
         # Check for unique return forms and handle the error message.
         unique_check_result = check_unique_return_forms(query_text)

--- a/src/scribe_data/check/check_query_forms.py
+++ b/src/scribe_data/check/check_query_forms.py
@@ -493,7 +493,7 @@ def check_forms_order(query_text: str) -> bool:
     return select_vars == where_vars
 
 
-# MARK: docstring Format
+# MARK: Docstring Format
 
 
 def check_docstring(query_text: str) -> bool:
@@ -502,16 +502,16 @@ def check_docstring(query_text: str) -> bool:
 
     Parameters
     ----------
-    query_text : str
-        The SPARQL query's text to be checked.
+        query_text : str
+            The SPARQL query's text to be checked.
 
     Returns
     -------
-    bool
-        True if the docstring is correctly formatted; otherwise, .
+        bool
+            True if the docstring is correctly formatted.
     """
     # Split the text into lines.
-    lines = query_text.splitlines(keepends=True)
+    query_lines = query_text.splitlines(keepends=True)
 
     # Regex patterns for each line in the docstring and corresponding error messages.
     patterns = [
@@ -525,11 +525,14 @@ def check_docstring(query_text: str) -> bool:
             "Error in line 3:",
         ),
     ]
-    # Check each line against its corresponding pattern.
-    for i, (pattern, error_line_number) in enumerate(patterns):
-        if not re.match(pattern, lines[i]):
-            return (False, f"{error_line_number} {lines[i].strip()}")
-    return True
+    return next(
+        (
+            (False, f"{error_line_number} {query_lines[i].strip()}")
+            for i, (pattern, error_line_number) in enumerate(patterns)
+            if not re.match(pattern, query_lines[i])
+        ),
+        True,
+    )
 
 
 # MARK: Main Query Forms Validation

--- a/src/scribe_data/wikidata/language_data_extraction/bengali/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/bengali/adjectives/query_adjectives.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Bengali (Bangla Q9610) adjectives (Q34698) and the given forms.
+# All Bengali (Q9610) adjectives (Q34698) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/bengali/adverbs/query_adverbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/bengali/adverbs/query_adverbs.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Bengali (Bangla Q9610) adverbs (Q380057) and the given forms.
+# All Bengali (Q9610) adverbs (Q380057) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/bengali/nouns/query_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/bengali/nouns/query_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Bengali (Bangla Q9610) nouns (Q1084) and the given forms.
+# All Bengali (Q9610) nouns (Q1084) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/bengali/postpositions/query_postpositions.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/bengali/postpositions/query_postpositions.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Bengali (Bangla Q9610) postpositions (Q161873) and the given forms.
+# All Bengali (Q9610) postpositions (Q161873) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 

--- a/src/scribe_data/wikidata/language_data_extraction/bengali/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/bengali/prepositions/query_prepositions.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Bengali (Bangla Q9610) prepositions (Q4833830) and the given forms.
+# All Bengali (Q9610) prepositions (Q4833830) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/bengali/proper_nouns/query_proper_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/bengali/proper_nouns/query_proper_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Bengali (Bangla Q9610) proper nouns (Q147276) and the given forms.
+# All Bengali (Q9610) proper nouns (Q147276) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/bengali/verbs/query_verbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/bengali/verbs/query_verbs.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Bengali (Bangla Q9610) verbs (Q24905) and the given forms.
+# All Bengali (Q9610) verbs (Q24905) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/dagbani/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/dagbani/adjectives/query_adjectives.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# Dagbani (Q32238) adjectives (Q34698) and the given forms.
+# All Dagbani (Q32238) adjectives (Q34698) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/dagbani/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/dagbani/prepositions/query_prepositions.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Dagbani (Q32238) prepositions and the given forms.
+# All Dagbani (Q32238) prepositions (Q4833830) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/dagbani/verbs/query_verbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/dagbani/verbs/query_verbs.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# Dagbani (Q32238) verbs and the given forms.
+# All Dagbani (Q32238) verbs (Q24905) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/adjectives/query_adjectives.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Hindi (from Hindustani Q11051) adjectives (Q34698) and the given forms..
+# All Hindi (Q11051) adjectives (Q34698) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "hi" to remove Urdu (ur) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/adjectives/query_adjectives.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Hindi (Q11051) adjectives (Q34698) and the given forms.
+# All Hindi Hindustani (Q11051) adjectives (Q34698) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "hi" to remove Urdu (ur) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/adverbs/query_adverbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/adverbs/query_adverbs.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Hindi (from Hindustani Q11051) adverbs (Q380057) and the given forms.
+# All Hindi (Q11051) adverbs (Q380057) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "hi" to remove Urdu (ur) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/adverbs/query_adverbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/adverbs/query_adverbs.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Hindi (Q11051) adverbs (Q380057) and the given forms.
+# All Hindi Hindustani (Q11051) adverbs (Q380057) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "hi" to remove Urdu (ur) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/nouns/query_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/nouns/query_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Hindi (Q11051) nouns (Q1084) and the given forms.
+# All Hindi Hindustani (Q11051) nouns (Q1084) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "hi" to remove Urdu (ur) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/nouns/query_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/nouns/query_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Hindi (from Hindustani Q11051) nouns (Q1084) and the given forms.
+# All Hindi (Q11051) nouns (Q1084) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "hi" to remove Urdu (ur) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/postpositions/query_postpositions.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/postpositions/query_postpositions.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Hindi (Q11051) postpositions (Q161873) and the given forms.
+# All Hindi Hindustani (Q11051) postpositions (Q161873) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "hi" to remove Urdu (ur) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/postpositions/query_postpositions.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/postpositions/query_postpositions.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Hindi (from Hindustani Q11051) postpositions (Q161873) and the given forms.
+# All Hindi (Q11051) postpositions (Q161873) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "hi" to remove Urdu (ur) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/prepositions/query_prepositions.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Hindi (from Hindustani Q11051) prepositions (Q4833830) and the given forms.
+# All Hindi (Q11051) prepositions (Q4833830) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "hi" to remove Urdu (ur) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/prepositions/query_prepositions.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Hindi (Q11051) prepositions (Q4833830) and the given forms.
+# All Hindi Hindustani (Q11051) prepositions (Q4833830) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "hi" to remove Urdu (ur) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/proper_nouns/query_proper_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/proper_nouns/query_proper_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Hindi (from Hindustani Q11051) proper nouns (Q147276) and the given forms.
+# All Hindi (Q11051) proper nouns (Q147276) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "hi" to remove Urdu (ur) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/proper_nouns/query_proper_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/proper_nouns/query_proper_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Hindi (Q11051) proper nouns (Q147276) and the given forms.
+# All Hindi Hindustani (Q11051) proper nouns (Q147276) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "hi" to remove Urdu (ur) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/verbs/query_verbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/verbs/query_verbs.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Hindi (from Hindustani Q11051) verbs (Q24905) and the given forms.
+# All Hindi (Q11051) verbs (Q24905) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "hi" to remove Urdu (ur) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/verbs/query_verbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/verbs/query_verbs.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Hindi (Q11051) verbs (Q24905) and the given forms.
+# All Hindi Hindustani (Q11051) verbs (Q24905) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "hi" to remove Urdu (ur) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/adjectives/query_adjectives.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Urdu (from Hindustani Q11051) adjectives (Q34698) and the given forms..
+# All Urdu (Q11051) adjectives (Q34698) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "ur" to remove Hindi (hi) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/adjectives/query_adjectives.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Urdu (Q11051) adjectives (Q34698) and the given forms.
+# All Urdu Hindustani (Q11051) adjectives (Q34698) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "ur" to remove Hindi (hi) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/adverbs/query_adverbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/adverbs/query_adverbs.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Urdu (Q11051) adverbs (Q380057) and the given forms.
+# All Urdu Hindustani (Q11051) adverbs (Q380057) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "ur" to remove Hindi (hi) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/nouns/query_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/nouns/query_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Urdu (Q11051) nouns (Q1084) and the given forms.
+# All Urdu Hindustani (Q11051) nouns (Q1084) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "ur" to remove Hindi (hi) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/nouns/query_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/nouns/query_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Urdu (from Hindustani Q11051) nouns (Q1084) and the given forms.
+# All Urdu (Q11051) nouns (Q1084) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "ur" to remove Hindi (hi) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/postpositions/query_postpositions.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/postpositions/query_postpositions.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Urdu (from Hindustani Q11051) postpositions (Q161873) and the given forms.
+# All Urdu (Q11051) postpositions (Q161873) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "ur" to remove Hindi (hi) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/postpositions/query_postpositions.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/postpositions/query_postpositions.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Urdu (Q11051) postpositions (Q161873) and the given forms.
+# All Urdu Hindustani (Q11051) postpositions (Q161873) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "ur" to remove Hindi (hi) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/prepositions/query_prepositions.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Urdu (from Hindustani Q11051) prepositions (Q4833830) and the given forms.
+# All Urdu (Q11051) prepositions (Q4833830) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "ur" to remove Hindi (hi) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/prepositions/query_prepositions.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Urdu (Q11051) prepositions (Q4833830) and the given forms.
+# All Urdu Hindustani (Q11051) prepositions (Q4833830) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "ur" to remove Hindi (hi) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/proper_nouns/query_proper_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/proper_nouns/query_proper_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Urdu (from Hindustani Q11051) proper nouns (Q147276) and the given forms.
+# All Urdu (Q11051) proper nouns (Q147276) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "ur" to remove Hindi (hi) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/proper_nouns/query_proper_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/proper_nouns/query_proper_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Urdu (Q11051) proper nouns (Q147276) and the given forms.
+# All Urdu Hindustani (Q11051) proper nouns (Q147276) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "ur" to remove Hindi (hi) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/verbs/query_verbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/verbs/query_verbs.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Urdu (from Hindustani Q11051) verbs and the currently implemented conjugations for each.
+# All Urdu (Q11051) verbs (Q24905) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "ur" to remove Hindustani (hi) words.

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/verbs/query_verbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/verbs/query_verbs.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Urdu (Q11051) verbs (Q24905) and the given forms.
+# All Urdu Hindustani (Q11051) verbs (Q24905) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "ur" to remove Hindustani (hi) words.

--- a/src/scribe_data/wikidata/language_data_extraction/indonesian/verbs/query_verbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/indonesian/verbs/query_verbs.sparql
@@ -1,5 +1,4 @@
 # tool: scribe-data
-# tool: scribe-data
 # All Indonesian (Q9240) verbs (Q24905) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 

--- a/src/scribe_data/wikidata/language_data_extraction/italian/verbs/query_verbs_3.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/italian/verbs/query_verbs_3.sparql
@@ -1,6 +1,5 @@
-
 # tool: scribe-data
-# All Italian (Q652) verbs and the currently implemented tenses for each.
+# All Italian (Q652) verbs (Q24905) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/malayalam/nouns/query_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/malayalam/nouns/query_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Malayalam (Q36236) nouns (Q1084) and the given forms and the given forms.
+# All Malayalam (Q36236) nouns (Q1084) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/malayalam/proper_nouns/query_proper_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/malayalam/proper_nouns/query_proper_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Malayalam (Q36236) proper nouns (Q147276) and the given forms and the given forms.
+# All Malayalam (Q36236) proper nouns (Q147276) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/norwegian/bokmål/adverbs/query_adverbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/norwegian/bokmål/adverbs/query_adverbs.sparql
@@ -1,16 +1,15 @@
 # tool: scribe-data
-# All Urdu (Q11051) adverbs (Q380057) and the given forms.
+# All Bokmål Norwegian (Q25167) adverbs (Q380057) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
-# Note: We need to filter for "ur" to remove Hindi (hi) words.
+# Note: This query is for Bokmål (Q25167) rather than Nynorsk (Q25164).
 
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?adverb
 
 WHERE {
-  ?lexeme dct:language wd:Q11051 ;
+  ?lexeme dct:language wd:Q25167 ;
     wikibase:lexicalCategory wd:Q380057 ;
     wikibase:lemma ?adverb .
-    FILTER(lang(?adverb) = "ur")
 }

--- a/src/scribe_data/wikidata/language_data_extraction/norwegian/bokmål/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/norwegian/bokmål/verbs/query_verbs_1.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Bokmål (Q25167) verbs and basic forms.
+# All Bokmål (Q25167) verbs (Q24905) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/norwegian/bokmål/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/norwegian/bokmål/verbs/query_verbs_2.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Bokmål (Q25167) verbs and additional forms.
+# All Bokmål (Q25167) verbs (Q24905) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/norwegian/nynorsk/adverbs/query_adverbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/norwegian/nynorsk/adverbs/query_adverbs.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Nynorsk Norwegian (Q25164) adverbs.
+# All Nynorsk Norwegian (Q25164) adverbs (Q380057) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: This query is for Nynorsk (Q25164) rather than Bokmål (Q25167).

--- a/src/scribe_data/wikidata/language_data_extraction/persian/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/persian/prepositions/query_prepositions.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All persian (Q9168) prepositions and the given forms.
+# All persian (Q9168) prepositions (Q4833830) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/persian/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/persian/verbs/query_verbs_2.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Persian (Q9168) verbs (Q24905) and their indicative aorist forms.
+# All Persian (Q9168) verbs (Q24905) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/persian/verbs/query_verbs_3.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/persian/verbs/query_verbs_3.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Persian (Q9168) verbs (Q24905) and the given forms, including past tense.
+# All Persian (Q9168) verbs (Q24905) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/persian/verbs/query_verbs_4.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/persian/verbs/query_verbs_4.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Persian (Q9168) verbs and the given present perfect tense forms.
+# All Persian (Q9168) verbs (Q24905) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/persian/verbs/query_verbs_5.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/persian/verbs/query_verbs_5.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Persian (Q9168) verbs (Q24905) and the given forms, including present subjunctive.
+# All Persian (Q9168) verbs (Q24905) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/punjabi/gurmukhi/adjectives/query_adjective.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/punjabi/gurmukhi/adjectives/query_adjective.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Gurmukhi (from Punjabi Q58635) adjectives (Q34698) and the given forms.
+# All Punjabi Gurmukhi (Q58635) adjectives (Q34698) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/punjabi/gurmukhi/adverbs/query_adverb.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/punjabi/gurmukhi/adverbs/query_adverb.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Gurmukhi (from Punjabi Q58635) adverbs (Q380057) and the given forms.
+# All Punjabi Shahmukhi (Q58635) adverbs (Q380057) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/punjabi/gurmukhi/nouns/query_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/punjabi/gurmukhi/nouns/query_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Gurmukhi (from Punjabi Q58635) nouns (Q1084) and the given forms.
+# All Punjabi Gurmukhi (Q58635) nouns (Q1084) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "pa" to select Gurmukhi words.

--- a/src/scribe_data/wikidata/language_data_extraction/punjabi/gurmukhi/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/punjabi/gurmukhi/prepositions/query_prepositions.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Gurmukhi (from Punjabi Q58635) prepositions (Q4833830) and the given forms.
+# All Punjabi Gurmukhi (Q58635) prepositions (Q4833830) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/punjabi/gurmukhi/proper_nouns/query_proper_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/punjabi/gurmukhi/proper_nouns/query_proper_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Gurmukhi (from Punjabi Q58635) proper nouns (Q147276) and the given forms.
+# All Punjabi Gurmukhi (Q58635) proper nouns (Q147276) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "pa" to select Gurmukhi words.

--- a/src/scribe_data/wikidata/language_data_extraction/punjabi/gurmukhi/verbs/query_verbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/punjabi/gurmukhi/verbs/query_verbs.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Gurmukhi (from Punjabi Q58635) verbs (Q24905) and the given forms.
+# All Punjabi Gurmukhi (Q58635) verbs (Q24905) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "pa" to select Gurmukhi words.

--- a/src/scribe_data/wikidata/language_data_extraction/punjabi/shahmukhi/adjectives/query_adjective.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/punjabi/shahmukhi/adjectives/query_adjective.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Shahmukhi (from Punjabi Q58635) adjectives (Q34698) and the given forms.
+# All Punjabi Shahmukhi (Q58635) adjectives (Q34698) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/punjabi/shahmukhi/adverbs/query_adverb.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/punjabi/shahmukhi/adverbs/query_adverb.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Shahmukhi (from Punjabi Q58635) adverbs (Q380057) and the given forms.
+# All Punjabi Shahmukhi (Q58635) adverbs (Q380057) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/punjabi/shahmukhi/nouns/query_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/punjabi/shahmukhi/nouns/query_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Shahmukhi (from Punjabi Q58635) nouns (Q1084) and the given forms.
+# All Punjabi Shahmukhi (Q58635) nouns (Q1084) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "pnb" to select Shahmukhi words.

--- a/src/scribe_data/wikidata/language_data_extraction/punjabi/shahmukhi/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/punjabi/shahmukhi/prepositions/query_prepositions.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Shahmukhi (from Punjabi Q58635) prepositions (Q4833830) and the given forms.
+# All Punjabi Shahmukhi (Q58635) prepositions (Q4833830) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/punjabi/shahmukhi/proper_nouns/query_proper_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/punjabi/shahmukhi/proper_nouns/query_proper_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Shahmukhi (from Punjabi Q58635) proper nouns (Q147276) and the given forms.
+# All Punjabi Shahmukhi (Q58635) proper nouns (Q147276) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "pnb" to select Shahmukhi words.

--- a/src/scribe_data/wikidata/language_data_extraction/punjabi/shahmukhi/verbs/query_verbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/punjabi/shahmukhi/verbs/query_verbs.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Shahmukhi (from Punjabi Q58635) verbs (Q24905) and the given forms.
+# All Punjabi Shahmukhi (Q58635) verbs (Q24905) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 # Note: We need to filter for "pnb" to select Shahmukhi words.

--- a/src/scribe_data/wikidata/language_data_extraction/sami/northern/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/sami/northern/adjectives/query_adjectives.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Northern Sami(Q33947) adjectives (Q34698) and the given forms.
+# All Northern Sami (Q33947) adjectives (Q34698) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/sami/northern/adverbs/query_adverbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/sami/northern/adverbs/query_adverbs.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Northern Sami(Q33947) adverbs (Q380057) and the given forms.
+# All Northern Sami (Q33947) adverbs (Q380057) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/sami/northern/nouns/query_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/sami/northern/nouns/query_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Northern Sami(Q33947) nouns (Q1084) and the given forms.
+# All Northern Sami (Q33947) nouns (Q1084) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT DISTINCT

--- a/src/scribe_data/wikidata/language_data_extraction/sami/northern/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/sami/northern/prepositions/query_prepositions.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Northern Sami(Q33947) prepositions (Q4833830) and the given forms.
+# All Northern Sami (Q33947) prepositions (Q4833830) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/sami/northern/proper_nouns/query_proper_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/sami/northern/proper_nouns/query_proper_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Northern Sami(Q33947) nouns (Q147276) and the given forms.
+# All Northern Sami (Q33947) nouns (Q147276) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/sami/northern/verbs/query_verbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/sami/northern/verbs/query_verbs.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Northern Sami(Q33947) verbs (Q24905) and the given forms.
+# All Northern Sami (Q33947) verbs (Q24905) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/swedish/prepositions/query_prepositions.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/swedish/prepositions/query_prepositions.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Swedish (Q9027) prepositions and the given forms.
+# All Swedish (Q9027) prepositions (Q4833830) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT

--- a/src/scribe_data/wikidata/language_data_extraction/tajik/proper_nouns/query_proper_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/tajik/proper_nouns/query_proper_nouns.sparql
@@ -1,5 +1,5 @@
 # tool: scribe-data
-# All Tajik (Q9260) proper nouns (Q147276)s and the given forms.
+# All Tajik (Q9260) proper nouns (Q147276) and the given forms.
 # Enter this query at https://query.wikidata.org/.
 
 SELECT


### PR DESCRIPTION
### Contributor checklist

<!-- Please replace the empty checkboxes [ ] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

1. **Docstring Validation Function**  
   - Added a new `check_docstring()` function that validates the docstrings in SPARQL query files.
   - Incorporated `check_docstring()` into the main validation process for automated checking.

2. **SPARQL Query File Fixes**  
   - Updated SPARQL query files based on the diagnostic results from the `check_docstring()` function.
   - Added a new SPARQL query file specifically for Bokmål adverbs.

### Testing

- Ran the main validation function check_query_forms in the terminal `py path to check_query_forms.py` .
- Ran `pytest`.

### Related issue
- #450
