### PR TITLE
Add `check_sparql_docstring_format` function to validate SPARQL query docstring format

### DIFF
--- a/src/scribe_data/check/check_query_forms.py
+++ b/src/scribe_data/check/check_query_forms.py
@@ -494,6 +494,8 @@ def check_forms_order(query_text: str) -> bool:
 
 
 # MARK: Main Query Forms Validation
+
+
 def check_query_forms() -> None:
     """
     Validates SPARQL queries in the language data directory to check for correct form QIDs.
@@ -593,6 +595,46 @@ def check_query_forms() -> None:
 
     else:
         print("All query forms are labeled and formatted correctly.")
+
+
+# Mark: Docstring Validation
+
+
+def check_sparql_docstring_format(file_path: Path) -> bool:
+    """
+    Checks if the SPARQL query docstring at the beginning of the file is correct and follows the specified format.
+
+    Parameters
+    ----------
+        file_path : Path
+            The path to the SPARQL query file to check.
+
+    Returns
+    -------
+        bool
+            True if the docstring format is correct, False otherwise.
+    """
+
+    docstring_patterns = [
+        r"# tool: scribe-data",
+        r"# All [A-Za-z]+ \(Q\d+\) [A-Za-z\s]+\ \(Q\d+\) and the given forms\.",
+        r"# Enter this query at https://query.wikidata.org/\."
+    ]
+
+    try:
+        with open(file_path, "r", encoding="utf-8") as file:
+            # Read the first few lines for the docstring
+            lines = [file.readline().strip() for _ in range(3)]
+
+            for line, pattern in zip(lines, docstring_patterns):
+                if not re.match(pattern, line):
+                    print(f"Docstring format error in {file_path}: '{line}' does not match '{pattern}'")
+                    return False
+            return True
+
+    except Exception as e:
+        print(f"Error reading {file_path}: {e}")
+        return False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

This PR introduces the check_sparql_docstring_format function to ensure SPARQL query files in the repository follow the required docstring format. This function performs validation checks to ensure consistency across query files, improving readability and maintaining expected standards for tool information and query instructions.

### Key Changes:

Added `check_sparql_docstring_format` function: This function takes a SPARQL query file as input, checks if the beginning docstring follows the prescribed format, and returns `True` or `False` based on the outcome.

### Docstring Format Verification:

The function verifies that the first three lines in the SPARQL query file match specific patterns:

```
# tool: scribe-data
# All [Language] (Q[ID]) [lexical category] (Q[ID]) and the given forms.
# Enter this query at https://query.wikidata.org/.
```

Uses regular expressions to match these patterns to ensure flexibility in language, category, and ID fields.
Error Handling: If a file fails to meet the required format, the function provides informative output indicating the nature and location of the format discrepancy.

### Motivation
This check will improve consistency in SPARQL query documentation across the repository, allowing both contributors and users to easily understand the purpose of each query. The standardized format also helps future-proof queries for documentation or programmatic usage within workflows.

### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #450 
