### PR TITLE
sub_languages logic fix in total and update rst doc

### DIFF
--- a/docs/source/scribe_data/cli.rst
+++ b/docs/source/scribe_data/cli.rst
@@ -143,14 +143,31 @@ Options:
 - ``-ot, --output-type {json,csv,tsv}``: The output file type.
 - ``-ope, --outputs-per-entry OUTPUTS_PER_ENTRY``: How many outputs should be generated per data entry.
 - ``-o, --overwrite``: Whether to overwrite existing files (default: False).
-- ``-a, --all ALL``: Get all languages and data types.
+- ``-a, --all``: Get all languages and data types. Can be combined with `-dt` to get all languages for a specific data type, or with `-lang` to get all data types for a specific language.
 - ``-i, --interactive``: Run in interactive mode.
 
-Example:
+Examples:
+
+.. code-block:: bash
+
+    $ scribe-data get --all
+    Getting data for all languages and all data types...
+
+.. code-block:: bash
+
+    $ scribe-data get --all -dt nouns
+    Getting all nouns for all languages...
+
+.. code-block:: bash
+
+    $ scribe-data get --all -lang English
+    Getting all data types for English...
 
 .. code-block:: bash
 
     $ scribe-data get -l English --data-type verbs -od ~/path/for/output
+    Getting and formatting English verbs
+    Data updated: 100%|████████████████████████| 1/1 [00:29<00:00, 29.73s/process]
 
 Behavior and Output:
 ^^^^^^^^^^^^^^^^^^^^
@@ -210,23 +227,30 @@ Interactive Mode
 .. code-block:: text
 
     $ scribe-data get -i
-    Welcome to Scribe-Data interactive mode!
-    Language options:
-    1. English
-    2. French
-    3. German
-    ...
+    Welcome to Scribe-Data v3.3.0 interactive mode!
+    ? What would you like to do? Configure request
+    Follow the prompts below. Press tab for completions and enter to select.
+    Select languages (comma-separated or type 'All'): english
+    Select data types (comma-separated or type 'All'): nouns
+    Select output type (json/csv/tsv): json
+    Enter output directory (default: scribe_data_json_export):
+    Overwrite existing files? (Y/n):
 
-    Please enter the languages to get data for, their numbers or (a) for all languages: 1
+    Scribe-Data Request Configuration Summary
+    ┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┓
+    ┃ Setting          ┃ Value(s)                ┃
+    ┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━┩
+    │ Languages        │ english                 │
+    │ Data Types       │ nouns                   │
+    │ Output Type      │ json                    │
+    │ Output Directory │ scribe_data_json_export │
+    │ Overwrite        │ Yes                     │
+    └──────────────────┴─────────────────────────┘
 
-    Data type options:
-    1. autosuggestions
-    2. emoji_keywords
-    3. nouns
-    4. prepositions
-    5. verbs
-
-    ...
+    ? What would you like to do? (Use arrow keys)
+     » Configure request
+       Run configured data request
+       Exit
 
 Total Command
 ~~~~~~~~~~~~~
@@ -242,30 +266,63 @@ Usage:
 Options:
 ^^^^^^^^
 
-- ``-lang, --language LANGUAGE``: The language(s) to check totals for.
+- ``-lang, --language LANGUAGE``: The language(s) to check totals for. Can be a language name or QID.
 - ``-dt, --data-type DATA_TYPE``: The data type(s) to check totals for.
-- ``-a, --all ALL``: Get totals for all languages and data types.
+- ``-a, --all``: Get totals for all languages and data types.
 
 Examples:
 
 .. code-block:: text
 
-    $scribe-data total -dt nouns  # verbs, adjectives, etc
-    Data type: nouns
-    Total number of lexemes: 123456
+    $ scribe-data total --all
+    Total lexemes for all languages and data types:
+    ==============================================
+    Language     Data Type     Total Lexemes
+    ==============================================
+    English      nouns         123456
+                 verbs         234567
+    ...
 
 .. code-block:: text
 
-    $scribe-data total -lang English
-    Language: English
-    Total number of lexemes: 123456
+    $ scribe-data total --language English
+    Returning total counts for English data types...
+
+    Language        Data Type                 Total Wikidata Lexemes
+    ================================================================
+    English         adjectives                12,848
+                    adverbs                   19,998
+                    nouns                     30,786
+    ...
 
 .. code-block:: text
 
-    $scribe-data total -lang English -dt nouns  # verbs, adjectives, etc
+    $ scribe-data total --language Q1860
+    Wikidata QID Q1860 passed. Checking all data types.
+
+    Language        Data Type                 Total Wikidata Lexemes
+    ================================================================
+    Q1860           adjectives                12,848
+                    adverbs                   19,998
+                    articles                  0
+                    conjunctions              72
+                    nouns                     30,786
+                    personal pronouns         32
+    ...
+
+.. code-block:: text
+
+    $ scribe-data total --language English -dt nouns
     Language: English
     Data type: nouns
     Total number of lexemes: 12345
+
+.. code-block:: text
+
+    $ scribe-data total --language Q1860 -dt verbs
+    Language: Q1860
+    Data type: verbs
+    Total number of lexemes: 23456
 
 Convert Command
 ~~~~~~~~~~~~~~~

--- a/tests/cli/test_total.py
+++ b/tests/cli/test_total.py
@@ -133,6 +133,42 @@ class TestTotalLexemes(unittest.TestCase):
         ]
         mock_print.assert_has_calls(expected_calls)
 
+    @patch("scribe_data.cli.total.get_qid_by_input")
+    @patch("scribe_data.cli.total.sparql.query")
+    @patch("scribe_data.cli.total.LANGUAGE_DATA_EXTRACTION_DIR")
+    def test_get_total_lexemes_sub_languages(self, mock_dir, mock_query, mock_get_qid):
+        # Setup for sub-languages
+        mock_get_qid.side_effect = lambda x: {
+            "bokmål": "Q25167",
+            "nynorsk": "Q25164",
+        }.get(x.lower())
+        mock_results = MagicMock()
+        mock_results.convert.return_value = {
+            "results": {"bindings": [{"total": {"value": "30"}}]}
+        }
+        mock_query.return_value = mock_results
+
+        # Mocking directory paths and contents
+        mock_dir.__truediv__.return_value.exists.return_value = True
+        mock_dir.__truediv__.return_value.iterdir.return_value = [
+            MagicMock(name="verbs", is_dir=lambda: True),
+            MagicMock(name="nouns", is_dir=lambda: True),
+        ]
+
+        with patch("builtins.print") as mock_print:
+            get_total_lexemes("Norwegian", "verbs")
+            get_total_lexemes("Norwegian", "nouns")
+
+        expected_calls = [
+            call(
+                "\nLanguage: Norwegian\nData type: verbs\nTotal number of lexemes: 30\n"
+            ),
+            call(
+                "\nLanguage: Norwegian\nData type: nouns\nTotal number of lexemes: 30\n"
+            ),
+        ]
+        mock_print.assert_has_calls(expected_calls)
+
 
 class TestGetQidByInput(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [X] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description
Updated total.py to handle sub_languages in [Language_metadata](https://github.com/scribe-org/Scribe-Data/blob/86226585c562075b3246cbbbd9f5cdc242bc91be/src/scribe_data/resources/language_metadata.json) 
![image](https://github.com/user-attachments/assets/5d17bb82-3416-4e04-a7dc-e2cacc2bf553) 
![image](https://github.com/user-attachments/assets/f7cea57b-de54-494a-9c29-f3e779742550)

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->
 
<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->
 