### PR TITLE
clean up language tests

### DIFF
--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -36,6 +36,7 @@ from scribe_data.cli.convert import (
 
 class TestConvert(unittest.TestCase):
     # MARK: Helper Function
+
     def normalize_line_endings(self, data: str) -> str:
         """
         Normalize line endings in a given string.
@@ -54,6 +55,7 @@ class TestConvert(unittest.TestCase):
         return data.replace("\r\n", "\n").replace("\r", "\n")
 
     # MARK: JSON
+
     @patch("scribe_data.cli.convert.Path", autospec=True)
     def test_convert_to_json_empty_language(self, mock_path):
         csv_data = "key,value\na,1\nb,2"

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -24,7 +24,7 @@ import json
 import unittest
 from io import StringIO
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, mock_open, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 from scribe_data.cli.convert import (
     convert_to_csv_or_tsv,
@@ -35,35 +35,7 @@ from scribe_data.cli.convert import (
 
 
 class TestConvert(unittest.TestCase):
-    # MARK: Helper Functions
-
-    def setup_language_map(self, mock_language_map: Mock) -> None:
-        """
-        Set up the mock language map for testing.
-
-        Parameters
-        ---------
-            mock_language_map: Mock
-                Mock object representing the language map
-                to be configured.
-
-        Returns
-        -------
-            None
-        """
-        mock_language_map.get.side_effect = lambda lang: {
-            "english": {
-                "language": "english",
-                "iso": "en",
-                "qid": "Q1860",
-            },
-            "french": {
-                "language": "french",
-                "iso": "fr",
-                "qid": "Q150",
-            },
-        }.get(lang.lower())
-
+    # MARK: Helper Function
     def normalize_line_endings(self, data: str) -> str:
         """
         Normalize line endings in a given string.
@@ -82,45 +54,27 @@ class TestConvert(unittest.TestCase):
         return data.replace("\r\n", "\n").replace("\r", "\n")
 
     # MARK: JSON
+    @patch("scribe_data.cli.convert.Path", autospec=True)
+    def test_convert_to_json_empty_language(self, mock_path):
+        csv_data = "key,value\na,1\nb,2"
+        mock_file = StringIO(csv_data)
 
-    # @patch("scribe_data.cli.convert.Path", autospec=True)
-    # def test_convert_to_json_normalized_language(self, mock_path):
-    #
+        mock_path_obj = MagicMock(spec=Path)
+        mock_path.return_value = mock_path_obj
+        mock_path_obj.suffix = ".csv"
+        mock_path_obj.exists.return_value = True
+        mock_path_obj.open.return_value.__enter__.return_value = mock_file
 
-    #     mock_path_obj = MagicMock(spec=Path)
-    #     mock_path.return_value = mock_path_obj
-
-    #     mock_path_obj.suffix = ".csv"
-    #     mock_path_obj.exists.return_value = True
-
-    #     convert_to_json(
-    #         language="French",
-    #         data_type="nouns",
-    #         output_type="json",
-    #         input_file="input.csv",
-    #         output_dir="/output_dir",
-    #         overwrite=True,
-    #     )
-
-    # @patch("scribe_data.cli.convert.Path", autospec=True)
-    # def test_convert_to_json_unknown_language(self, mock_path):
-    #     mock_input_file_path = MagicMock(spec=Path)
-    #     mock_input_file_path.exists.return_value = True
-    #     mock_path.side_effect = [mock_input_file_path, MagicMock(spec=Path)]
-
-    #     with self.assertRaises(ValueError) as context:
-    #         convert_to_json(
-    #             language="FakeLanguage",
-    #             data_type="nouns",
-    #             output_type="json",
-    #             input_file="test.csv",
-    #             output_dir="/output_dir",
-    #             overwrite=True,
-    #         )
-
-    #     self.assertEqual(
-    #         str(context.exception), "Language 'FakeLanguage' is not recognized."
-    #     )
+        with self.assertRaises(ValueError) as context:
+            convert_to_json(
+                language="",
+                data_type="nouns",
+                output_type="json",
+                input_file="input.csv",
+                output_dir="/output_dir",
+                overwrite=True,
+            )
+        self.assertIn("Language '' is not recognized.", str(context.exception))
 
     @patch("scribe_data.cli.convert.Path", autospec=True)
     def test_convert_to_json_with_input_file(self, mock_path):
@@ -146,7 +100,7 @@ class TestConvert(unittest.TestCase):
 
         mock_path_obj.open.assert_called_once_with("r", encoding="utf-8")
 
-    @patch("scribe_data.cli.convert.Path")
+    @patch("scribe_data.cli.convert.Path", autospec=True)
     def test_convert_to_json_supported_file_extension_csv(self, mock_path_class):
         mock_path_instance = MagicMock(spec=Path)
 
@@ -164,7 +118,7 @@ class TestConvert(unittest.TestCase):
             overwrite=True,
         )
 
-    @patch("scribe_data.cli.convert.Path")
+    @patch("scribe_data.cli.convert.Path", autospec=True)
     def test_convert_to_json_supported_file_extension_tsv(self, mock_path_class):
         mock_path_instance = MagicMock(spec=Path)
 
@@ -182,7 +136,7 @@ class TestConvert(unittest.TestCase):
             overwrite=True,
         )
 
-    @patch("scribe_data.cli.convert.Path")
+    @patch("scribe_data.cli.convert.Path", autospec=True)
     def test_convert_to_json_unsupported_file_extension(self, mock_path):
         mock_path_obj = MagicMock(spec=Path)
         mock_path.return_value = mock_path_obj
@@ -322,62 +276,29 @@ class TestConvert(unittest.TestCase):
 
     # MARK: CSV or TSV
 
-    # @patch("scribe_data.cli.convert.Path", autospec=True)
-    # def test_convert_to_csv_or_json_normalized_language(
-    #     self, mock_path
-    # ):
-    #
+    @patch("scribe_data.cli.convert.Path", autospec=True)
+    def test_convert_to_csv_or_json_empty_language(self, mock_path):
+        mock_path_obj = MagicMock(spec=Path)
+        mock_path.return_value = mock_path_obj
 
-    #     mock_path_obj = MagicMock(spec=Path)
-    #     mock_path.return_value = mock_path_obj
+        mock_path_obj.suffix = ".json"
+        mock_path_obj.exists.return_value = True
 
-    #     mock_path_obj.suffix = ".json"
-    #     mock_path_obj.exists.return_value = True
+        mock_json_data = json.dumps({"key1": "value1", "key2": "value2"})
+        mock_open_function = mock_open(read_data=mock_json_data)
+        mock_path_obj.open = mock_open_function
 
-    #     mock_json_data = json.dumps({"key1": "value1", "key2": "value2"})
-    #     mock_open_function = mock_open(read_data=mock_json_data)
-    #     mock_path_obj.open = mock_open_function
+        with self.assertRaises(ValueError) as context:
+            convert_to_csv_or_tsv(
+                language="",
+                data_type="nouns",
+                output_type="csv",
+                input_file="input.json",
+                output_dir="/output_dir",
+                overwrite=True,
+            )
 
-    #     convert_to_csv_or_tsv(
-    #         language="English",
-    #         data_type="nouns",
-    #         output_type="csv",
-    #         input_file="input.json",
-    #         output_dir="/output_dir",
-    #         overwrite=True,
-    #     )
-
-    #     mock_open_function.assert_called_once_with("r", encoding="utf-8")
-
-    # @patch("scribe_data.cli.convert.Path", autospec=True)
-    # def test_convert_to_csv_or_json_unknown_language(
-    #     self, mock_path
-    # ):
-    #
-
-    #     mock_path_obj = MagicMock(spec=Path)
-    #     mock_path.return_value = mock_path_obj
-
-    #     mock_path_obj.suffix = ".json"
-    #     mock_path_obj.exists.return_value = True
-
-    #     mock_json_data = json.dumps({"key1": "value1", "key2": "value2"})
-    #     mock_open_function = mock_open(read_data=mock_json_data)
-    #     mock_path_obj.open = mock_open_function
-
-    #     with self.assertRaises(ValueError) as context:
-    #         convert_to_csv_or_tsv(
-    #             language="FakeLanguage",
-    #             data_type="nouns",
-    #             output_type="csv",
-    #             input_file="input.json",
-    #             output_dir="/output_dir",
-    #             overwrite=True,
-    #         )
-
-    #     self.assertEqual(
-    #         str(context.exception), "Language 'FakeLanguage' is not recognized."
-    #     )
+        self.assertEqual(str(context.exception), "Language '' is not recognized.")
 
     @patch("scribe_data.cli.convert.Path", autospec=True)
     def test_convert_to_csv_or_tsv_standarddict_to_csv(self, mock_path_class):
@@ -710,8 +631,8 @@ class TestConvert(unittest.TestCase):
 
     # MARK: SQLITE
 
-    @patch("scribe_data.cli.convert.Path")
-    @patch("scribe_data.cli.convert.data_to_sqlite")
+    @patch("scribe_data.cli.convert.Path", autospec=True)
+    @patch("scribe_data.cli.convert.data_to_sqlite", autospec=True)
     @patch("shutil.copy")
     def test_convert_to_sqlite(self, mock_shutil_copy, mock_data_to_sqlite, mock_path):
         mock_path.return_value.exists.return_value = True
@@ -728,8 +649,8 @@ class TestConvert(unittest.TestCase):
         mock_data_to_sqlite.assert_called_with(["english"], ["nouns"])
         mock_shutil_copy.assert_called()
 
-    @patch("scribe_data.cli.convert.Path")
-    @patch("scribe_data.cli.convert.data_to_sqlite")
+    @patch("scribe_data.cli.convert.Path", autospec=True)
+    @patch("scribe_data.cli.convert.data_to_sqlite", autospec=True)
     def test_convert_to_sqlite_no_output_dir(self, mock_data_to_sqlite, mock_path):
         mock_input_file = MagicMock()
         mock_input_file.exists.return_value = True
@@ -751,9 +672,9 @@ class TestConvert(unittest.TestCase):
 
         mock_data_to_sqlite.assert_called_with(["english"], ["nouns"])
 
-    @patch("scribe_data.cli.convert.Path")
-    @patch("scribe_data.cli.convert.data_to_sqlite")
-    @patch("scribe_data.cli.convert.get_language_iso")
+    @patch("scribe_data.cli.convert.Path", autospec=True)
+    @patch("scribe_data.cli.convert.data_to_sqlite", autospec=True)
+    @patch("scribe_data.cli.convert.get_language_iso", autospec=True)
     @patch("shutil.copy")
     def test_convert_to_sqlite_with_language_iso(
         self, mock_copy, mock_get_language_iso, mock_data_to_sqlite, mock_path


### PR DESCRIPTION
### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

This pull request addresses issue #496 by improving test coverage and accuracy for the language tests within `tests/cli/test_convert.py`. It involves uncommenting the existing tests and modifying them to align with the new language metadata.

I tested my changes by running the `pytest` command, which confirmed that all tests were passing successfully and that the updated tests correctly validated the expected behavior.

### Related issue

- #496
