### PR TITLE
Add optional QID order validation and refactor label decomposition

### DIFF
--- a/src/scribe_data/check/check_query_forms.py
+++ b/src/scribe_data/check/check_query_forms.py
@@ -507,9 +507,7 @@ def check_optional_qid_order(query_file: str) -> str:
     """
     forms = extract_forms_from_sparql(query_file)
     error_messages = []
-    statement_index = 0
     for form_text in forms:
-        statement_index += 1
         if "ontolex:lexicalForm" in form_text and "ontolex:representation" in form_text:
             # Extract the actual QIDs and label for the current form.
             actual_qids = extract_form_qids(form_text=form_text)
@@ -517,11 +515,15 @@ def check_optional_qid_order(query_file: str) -> str:
             label_components = decompose_label_features(form_label)
             expected_qids = [qid_label_dict[key] for key in label_components]
 
+            # Keep PastParticiple and imperfective QIDs as is in the query since we have duplicate qids for it.
+            for i in ["Q12717679", "Q1230649", "Q2898727", "Q54556033"]:
+                if i in actual_qids and i not in expected_qids:
+                    expected_qids[actual_qids.index(i)] = i
             # Check if the actual QIDs match the expected order.
-            if actual_qids != expected_qids:
+            if len(actual_qids) == len(expected_qids) and actual_qids != expected_qids:
                 formatted_qids = ", ".join(f"wd:{qid}" for qid in expected_qids) + " ."
                 error_messages.append(
-                    f"QIDs in optional statement number {statement_index} should be ordered this way: \n {formatted_qids}"
+                    f"\nThe QIDs in optional statement for {form_label} should be ordered:\n{formatted_qids}"
                 )
     return "\n".join(error_messages) if error_messages else ""
 

--- a/src/scribe_data/wikidata/language_data_extraction/arabic/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/arabic/adjectives/query_adjectives.sparql
@@ -46,81 +46,77 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeFeminineIndefiniteSingularForm .
     ?nominativeFeminineIndefiniteSingularForm ontolex:representation ?nominativeFeminineIndefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110786, wd:Q131105, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q1775415, wd:Q53997857, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeFeminineIndefinitePluralForm .
     ?nominativeFeminineIndefinitePluralForm ontolex:representation ?nominativeFeminineIndefinitePlural ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q146786, wd:Q131105, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q1775415, wd:Q53997857, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeFeminineIndefiniteDualForm .
     ?nominativeFeminineIndefiniteDualForm ontolex:representation ?nominativeFeminineIndefiniteDual ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110022, wd:Q131105, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q1775415, wd:Q53997857, wd:Q110022 .
   }
 
   # Masculine
-
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeMasculineIndefiniteSingularForm .
     ?nominativeMasculineIndefiniteSingularForm ontolex:representation ?nominativeMasculineIndefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110786, wd:Q131105, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q499327, wd:Q53997857, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeMasculineIndefinitePluralForm .
     ?nominativeMasculineIndefinitePluralForm ontolex:representation ?nominativeMasculineIndefinitePlural ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q146786, wd:Q131105, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q499327, wd:Q53997857, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeMasculineIndefiniteDualForm .
     ?nominativeMasculineIndefiniteDualForm ontolex:representation ?nominativeMasculineIndefiniteDual ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110022, wd:Q131105, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q499327, wd:Q53997857, wd:Q110022 .
   }
 
   # MARK: Genitive
-
   # Feminine
-
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveFeminineIndefiniteSingularForm .
     ?genitiveFeminineIndefiniteSingularForm ontolex:representation ?genitiveFeminineIndefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110786, wd:Q146233, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q146233, wd:Q1775415, wd:Q53997857, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveFeminineIndefinitePluralForm .
     ?genitiveFeminineIndefinitePluralForm ontolex:representation ?genitiveFeminineIndefinitePlural ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q146786, wd:Q146233, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q146233, wd:Q1775415, wd:Q53997857, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveFeminineIndefiniteDualForm .
     ?genitiveFeminineIndefiniteDualForm ontolex:representation ?genitiveFeminineIndefiniteDual ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110022, wd:Q146233, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q146233, wd:Q1775415, wd:Q53997857, wd:Q110022 .
   }
 
   # Masculine
-
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveMasculineIndefiniteSingularForm .
     ?genitiveMasculineIndefiniteSingularForm ontolex:representation ?genitiveMasculineIndefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110786, wd:Q146233, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q146233, wd:Q499327, wd:Q53997857, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveMasculineIndefinitePluralForm .
     ?genitiveMasculineIndefinitePluralForm ontolex:representation ?genitiveMasculineIndefinitePlural ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q146786, wd:Q146233, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q146233, wd:Q499327, wd:Q53997857, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveMasculineIndefiniteDualForm .
     ?genitiveMasculineIndefiniteDualForm ontolex:representation ?genitiveMasculineIndefiniteDual ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110022, wd:Q146233, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q146233, wd:Q499327, wd:Q53997857, wd:Q110022 .
   }
 
   # MARK: Accusative
@@ -130,19 +126,19 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeFeminineIndefiniteSingularForm .
     ?accusativeFeminineIndefiniteSingularForm ontolex:representation ?accusativeFeminineIndefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110786, wd:Q146078, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q146078, wd:Q1775415, wd:Q53997857, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeFeminineIndefinitePluralForm .
     ?accusativeFeminineIndefinitePluralForm ontolex:representation ?accusativeFeminineIndefinitePlural ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q146786, wd:Q146078, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q146078, wd:Q1775415, wd:Q53997857, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeFeminineIndefiniteDualForm .
     ?accusativeFeminineIndefiniteDualForm ontolex:representation ?accusativeFeminineIndefiniteDual ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110022, wd:Q146078, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q146078, wd:Q1775415, wd:Q53997857, wd:Q110022 .
   }
 
   # Masculine
@@ -150,19 +146,19 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeMasculineIndefiniteSingularForm .
     ?accusativeMasculineIndefiniteSingularForm ontolex:representation ?accusativeMasculineIndefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110786, wd:Q146078, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q146078, wd:Q499327, wd:Q53997857, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeMasculineIndefinitePluralForm .
     ?accusativeMasculineIndefinitePluralForm ontolex:representation ?accusativeMasculineIndefinitePlural ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q146786, wd:Q146078, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q146078, wd:Q499327, wd:Q53997857, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeMasculineIndefiniteDualForm .
     ?accusativeMasculineIndefiniteDualForm ontolex:representation ?accusativeMasculineIndefiniteDual ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110022, wd:Q146078, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q146078, wd:Q499327, wd:Q53997857, wd:Q110022 .
   }
 
   # MARK: Pausal
@@ -172,38 +168,40 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pausalFeminineIndefiniteSingularForm .
     ?pausalFeminineIndefiniteSingularForm ontolex:representation ?pausalFeminineIndefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110786, wd:Q117262361, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q117262361, wd:Q1775415, wd:Q53997857, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pausalFeminineIndefinitePluralForm .
     ?pausalFeminineIndefinitePluralForm ontolex:representation ?pausalFeminineIndefinitePlural ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q146786, wd:Q117262361, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q117262361, wd:Q1775415, wd:Q53997857, wd:Q146786 .
   }
+
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pausalFeminineIndefiniteDualForm .
     ?pausalFeminineIndefiniteDualForm ontolex:representation ?pausalFeminineIndefiniteDual ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110022, wd:Q117262361, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q117262361, wd:Q1775415, wd:Q53997857, wd:Q110022 .
   }
+
 
   # Masculine
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pausalMasculineIndefiniteSingularForm .
     ?pausalMasculineIndefiniteSingularForm ontolex:representation ?pausalMasculineIndefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110786, wd:Q117262361, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q117262361, wd:Q499327, wd:Q53997857, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pausalMasculineIndefinitePluralForm .
     ?pausalMasculineIndefinitePluralForm ontolex:representation ?pausalMasculineIndefinitePlural ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q146786, wd:Q117262361, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q117262361, wd:Q499327, wd:Q53997857, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pausalMasculineIndefiniteDualForm .
     ?pausalMasculineIndefiniteDualForm ontolex:representation ?pausalMasculineIndefiniteDual ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110022, wd:Q117262361, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q117262361, wd:Q499327, wd:Q53997857, wd:Q110022 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/arabic/nouns/query_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/arabic/nouns/query_nouns.sparql
@@ -46,40 +46,40 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeFeminineIndefiniteSingularForm .
     ?nominativeFeminineIndefiniteSingularForm ontolex:representation ?nominativeFeminineIndefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110786, wd:Q131105, wd:Q53997857 .
-  }
+      wikibase:grammaticalFeature wd:Q131105, wd:Q1775415, wd:Q53997857, wd:Q110786 .
+}
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeFeminineIndefinitePluralForm .
     ?nominativeFeminineIndefinitePluralForm ontolex:representation ?nominativeFeminineIndefinitePlural ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q146786, wd:Q131105, wd:Q53997857 .
-  }
+      wikibase:grammaticalFeature wd:Q131105, wd:Q1775415, wd:Q53997857, wd:Q146786 .
+}
 
-  OPTIONAL {
+OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeFeminineIndefiniteDualForm .
     ?nominativeFeminineIndefiniteDualForm ontolex:representation ?nominativeFeminineIndefiniteDual ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110022, wd:Q131105, wd:Q53997857 .
-  }
+      wikibase:grammaticalFeature wd:Q131105, wd:Q1775415, wd:Q53997857, wd:Q110022 .
+}
 
   # Masculine
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeMasculineIndefiniteSingularForm .
     ?nominativeMasculineIndefiniteSingularForm ontolex:representation ?nominativeMasculineIndefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110786, wd:Q131105, wd:Q53997857 .
-  }
+      wikibase:grammaticalFeature wd:Q131105, wd:Q499327, wd:Q53997857, wd:Q110786 .
+}
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeMasculineIndefinitePluralForm .
     ?nominativeMasculineIndefinitePluralForm ontolex:representation ?nominativeMasculineIndefinitePlural ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q146786, wd:Q131105, wd:Q53997857 .
-  }
+      wikibase:grammaticalFeature wd:Q131105, wd:Q499327, wd:Q53997857, wd:Q146786 .
+}
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeMasculineIndefiniteDualForm .
     ?nominativeMasculineIndefiniteDualForm ontolex:representation ?nominativeMasculineIndefiniteDual ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110022, wd:Q131105, wd:Q53997857 .
-  }
+      wikibase:grammaticalFeature wd:Q131105, wd:Q499327, wd:Q53997857, wd:Q110022 .
+}
 
   # MARK: Genitive
 
@@ -88,82 +88,82 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveFeminineIndefiniteSingularForm .
     ?genitiveFeminineIndefiniteSingularForm ontolex:representation ?genitiveFeminineIndefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110786, wd:Q146233, wd:Q53997857 .
-  }
+      wikibase:grammaticalFeature wd:Q146233, wd:Q1775415, wd:Q53997857, wd:Q110786 .
+}
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveFeminineIndefinitePluralForm .
     ?genitiveFeminineIndefinitePluralForm ontolex:representation ?genitiveFeminineIndefinitePlural ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q146786, wd:Q146233, wd:Q53997857 .
-  }
+      wikibase:grammaticalFeature wd:Q146233, wd:Q1775415, wd:Q53997857, wd:Q146786 .
+}
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveFeminineIndefiniteDualForm .
     ?genitiveFeminineIndefiniteDualForm ontolex:representation ?genitiveFeminineIndefiniteDual ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110022, wd:Q146233, wd:Q53997857 .
-  }
+      wikibase:grammaticalFeature wd:Q146233, wd:Q1775415, wd:Q53997857, wd:Q110022 .
+}
 
   # Masculine
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveMasculineIndefiniteSingularForm .
     ?genitiveMasculineIndefiniteSingularForm ontolex:representation ?genitiveMasculineIndefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110786, wd:Q146233, wd:Q53997857 .
-  }
+      wikibase:grammaticalFeature wd:Q146233, wd:Q499327, wd:Q53997857, wd:Q110786 .
+}
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveMasculineIndefinitePluralForm .
     ?genitiveMasculineIndefinitePluralForm ontolex:representation ?genitiveMasculineIndefinitePlural ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q146786, wd:Q146233, wd:Q53997857 .
-  }
+      wikibase:grammaticalFeature wd:Q146233, wd:Q499327, wd:Q53997857, wd:Q146786 .
+}
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveMasculineIndefiniteDualForm .
     ?genitiveMasculineIndefiniteDualForm ontolex:representation ?genitiveMasculineIndefiniteDual ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110022, wd:Q146233, wd:Q53997857 .
-  }
+      wikibase:grammaticalFeature wd:Q146233, wd:Q499327, wd:Q53997857, wd:Q110022 .
+}
 
   # MARK: Accusative
 
   # Feminine
 
-  OPTIONAL {
+OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeFeminineIndefiniteSingularForm .
     ?accusativeFeminineIndefiniteSingularForm ontolex:representation ?accusativeFeminineIndefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110786, wd:Q146078, wd:Q53997857 .
-  }
+      wikibase:grammaticalFeature wd:Q146078, wd:Q1775415, wd:Q53997857, wd:Q110786 .
+}
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeFeminineIndefinitePluralForm .
     ?accusativeFeminineIndefinitePluralForm ontolex:representation ?accusativeFeminineIndefinitePlural ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q146786, wd:Q146078, wd:Q53997857 .
-  }
+      wikibase:grammaticalFeature wd:Q146078, wd:Q1775415, wd:Q53997857, wd:Q146786 .
+}
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeFeminineIndefiniteDualForm .
     ?accusativeFeminineIndefiniteDualForm ontolex:representation ?accusativeFeminineIndefiniteDual ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110022, wd:Q146078, wd:Q53997857 .
-  }
+      wikibase:grammaticalFeature wd:Q146078, wd:Q1775415, wd:Q53997857, wd:Q110022 .
+}
 
   # Masculine
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeMasculineIndefiniteSingularForm .
     ?accusativeMasculineIndefiniteSingularForm ontolex:representation ?accusativeMasculineIndefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110786, wd:Q146078, wd:Q53997857 .
-  }
+      wikibase:grammaticalFeature wd:Q146078, wd:Q499327, wd:Q53997857, wd:Q110786 .
+}
 
-  OPTIONAL {
+OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeMasculineIndefinitePluralForm .
     ?accusativeMasculineIndefinitePluralForm ontolex:representation ?accusativeMasculineIndefinitePlural ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q146786, wd:Q146078, wd:Q53997857 .
-  }
+      wikibase:grammaticalFeature wd:Q146078, wd:Q499327, wd:Q53997857, wd:Q146786 .
+}
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeMasculineIndefiniteDualForm .
     ?accusativeMasculineIndefiniteDualForm ontolex:representation ?accusativeMasculineIndefiniteDual ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110022, wd:Q146078, wd:Q53997857 .
-  }
+      wikibase:grammaticalFeature wd:Q146078, wd:Q499327, wd:Q53997857, wd:Q110022 .
+}
 
   # MARK: Pausal
 
@@ -172,19 +172,19 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pausalFeminineIndefiniteSingularForm .
     ?pausalFeminineIndefiniteSingularForm ontolex:representation ?pausalFeminineIndefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110786, wd:Q117262361, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q117262361, wd:Q1775415, wd:Q53997857, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pausalFeminineIndefinitePluralForm .
     ?pausalFeminineIndefinitePluralForm ontolex:representation ?pausalFeminineIndefinitePlural ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q146786, wd:Q117262361, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q117262361, wd:Q1775415, wd:Q53997857, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pausalFeminineIndefiniteDualForm .
     ?pausalFeminineIndefiniteDualForm ontolex:representation ?pausalFeminineIndefiniteDual ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110022, wd:Q117262361, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q117262361, wd:Q1775415, wd:Q53997857, wd:Q110022 .
   }
 
   # Masculine
@@ -192,18 +192,18 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pausalMasculineIndefiniteSingularForm .
     ?pausalMasculineIndefiniteSingularForm ontolex:representation ?pausalMasculineIndefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110786, wd:Q117262361, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q117262361, wd:Q499327, wd:Q53997857, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pausalMasculineIndefinitePluralForm .
     ?pausalMasculineIndefinitePluralForm ontolex:representation ?pausalMasculineIndefinitePlural ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q146786, wd:Q117262361, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q117262361, wd:Q499327, wd:Q53997857, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pausalMasculineIndefiniteDualForm .
     ?pausalMasculineIndefiniteDualForm ontolex:representation ?pausalMasculineIndefiniteDual ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110022, wd:Q117262361, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q117262361, wd:Q499327, wd:Q53997857, wd:Q110022 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/arabic/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/arabic/verbs/query_verbs_1.sparql
@@ -26,70 +26,69 @@ WHERE {
     wikibase:lemma ?verb .
 
   # MARK: Indicative Present
-
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeFirstPersonSingularFiilMudariForm .
     ?indicativeFirstPersonSingularFiilMudariForm ontolex:representation ?indicativeFirstPersonSingularFiilMudari ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q682111, wd:Q12230930 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q21714344, wd:Q110786, wd:Q12230930 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeFirstPersonPluralFiilMudariForm .
     ?indicativeFirstPersonPluralFiilMudariForm ontolex:representation ?indicativeFirstPersonPluralFiilMudari ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q682111, wd:Q12230930 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q21714344, wd:Q146786, wd:Q12230930 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeSecondPersonDualFiilMudariForm .
     ?indicativeSecondPersonDualFiilMudariForm ontolex:representation ?indicativeSecondPersonDualFiilMudari ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110022, wd:Q682111, wd:Q12230930 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q51929049, wd:Q110022, wd:Q12230930 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?feminineIndicativeSecondPersonSingularFiilMudariForm .
     ?feminineIndicativeSecondPersonSingularFiilMudariForm ontolex:representation ?feminineIndicativeSecondPersonSingularFiilMudari ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q1775415, wd:Q682111, wd:Q12230930 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q682111, wd:Q51929049, wd:Q110786, wd:Q12230930 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?feminineIndicativeSecondPersonPluralFiilMudariForm .
     ?feminineIndicativeSecondPersonPluralFiilMudariForm ontolex:representation ?feminineIndicativeSecondPersonPluralFiilMudari ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q1775415, wd:Q682111, wd:Q12230930 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q682111, wd:Q51929049, wd:Q146786, wd:Q12230930 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?feminineIndicativeThirdPersonSingularFiilMudariForm .
     ?feminineIndicativeThirdPersonSingularFiilMudariForm ontolex:representation ?feminineIndicativeThirdPersonSingularFiilMudari ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q1775415, wd:Q682111, wd:Q12230930 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q682111, wd:Q51929074, wd:Q110786, wd:Q12230930 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?feminineIndicativeThirdPersonDualFiilMudariForm .
     ?feminineIndicativeThirdPersonDualFiilMudariForm ontolex:representation ?feminineIndicativeThirdPersonDualFiilMudari ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110022, wd:Q1775415, wd:Q682111, wd:Q12230930 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q682111, wd:Q51929074, wd:Q110022, wd:Q12230930 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineIndicativeSecondPersonSingularFiilMudariForm .
     ?masculineIndicativeSecondPersonSingularFiilMudariForm ontolex:representation ?masculineIndicativeSecondPersonSingularFiilMudari ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q499327, wd:Q682111, wd:Q12230930 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q682111, wd:Q51929049, wd:Q110786, wd:Q12230930 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineIndicativeSecondPersonPluralFiilMudariForm .
     ?masculineIndicativeSecondPersonPluralFiilMudariForm ontolex:representation ?masculineIndicativeSecondPersonPluralFiilMudari ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q499327, wd:Q682111, wd:Q12230930 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q682111, wd:Q51929049, wd:Q146786, wd:Q12230930 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineIndicativeThirdPersonSingularFiilMudariForm .
     ?masculineIndicativeThirdPersonSingularFiilMudariForm ontolex:representation ?masculineIndicativeThirdPersonSingularFiilMudari ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q499327, wd:Q682111, wd:Q12230930 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q682111, wd:Q51929074, wd:Q110786, wd:Q12230930 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineIndicativeThirdPersonDualFiilMudariForm .
     ?masculineIndicativeThirdPersonDualFiilMudariForm ontolex:representation ?masculineIndicativeThirdPersonDualFiilMudari ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110022, wd:Q499327, wd:Q682111, wd:Q12230930 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q682111, wd:Q51929074, wd:Q110022, wd:Q12230930 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/arabic/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/arabic/verbs/query_verbs_2.sparql
@@ -30,66 +30,66 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?activePerformativeFirstPersonSingularForm .
     ?activePerformativeFirstPersonSingularForm ontolex:representation ?activePerformativeFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q1317831, wd:Q124351233 .
+      wikibase:grammaticalFeature wd:Q1317831, wd:Q124351233, wd:Q21714344, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?activePerformativeFirstPersonPluralForm .
     ?activePerformativeFirstPersonPluralForm ontolex:representation ?activePerformativeFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q1317831, wd:Q124351233 .
+      wikibase:grammaticalFeature wd:Q1317831, wd:Q124351233, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?activePerformativeSecondPersonDualForm .
     ?activePerformativeSecondPersonDualForm ontolex:representation ?activePerformativeSecondPersonDual ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110022, wd:Q1317831, wd:Q124351233 .
+      wikibase:grammaticalFeature wd:Q1317831, wd:Q124351233, wd:Q51929049, wd:Q110022 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?feminineActivePerformativeSecondPersonSingularForm .
     ?feminineActivePerformativeSecondPersonSingularForm ontolex:representation ?feminineActivePerformativeSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q1775415, wd:Q1317831, wd:Q124351233 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q1317831, wd:Q124351233, wd:Q51929049, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?feminineActivePerformativeSecondPersonPluralForm .
     ?feminineActivePerformativeSecondPersonPluralForm ontolex:representation ?feminineActivePerformativeSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q1775415, wd:Q1317831, wd:Q124351233 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q1317831, wd:Q124351233, wd:Q51929049, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?feminineActivePerformativeThirdPersonSingularForm .
     ?feminineActivePerformativeThirdPersonSingularForm ontolex:representation ?feminineActivePerformativeThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q1775415, wd:Q1317831, wd:Q124351233 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q1317831, wd:Q124351233, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?feminineActivePerformativeThirdPersonDualForm .
     ?feminineActivePerformativeThirdPersonDualForm ontolex:representation ?feminineActivePerformativeThirdPersonDual ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110022, wd:Q1775415, wd:Q1317831, wd:Q124351233 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q1317831, wd:Q124351233, wd:Q51929074, wd:Q110022 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineActivePerformativeSecondPersonSingularForm .
     ?masculineActivePerformativeSecondPersonSingularForm ontolex:representation ?masculineActivePerformativeSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q499327, wd:Q1317831, wd:Q124351233 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q1317831, wd:Q124351233, wd:Q51929049, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineActivePerformativeSecondPersonPluralForm .
     ?masculineActivePerformativeSecondPersonPluralForm ontolex:representation ?masculineActivePerformativeSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q499327, wd:Q1317831, wd:Q124351233 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q1317831, wd:Q124351233, wd:Q51929049, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineActivePerformativeThirdPersonSingularForm .
     ?masculineActivePerformativeThirdPersonSingularForm ontolex:representation ?masculineActivePerformativeThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q499327, wd:Q1317831, wd:Q124351233 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q1317831, wd:Q124351233, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineActivePerformativeThirdPersonDualForm .
     ?masculineActivePerformativeThirdPersonDualForm ontolex:representation ?masculineActivePerformativeThirdPersonDual ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110022, wd:Q499327, wd:Q1317831, wd:Q124351233 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q1317831, wd:Q124351233, wd:Q51929074, wd:Q110022 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/czech/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/czech/verbs/query_verbs_1.sparql
@@ -49,7 +49,7 @@ WHERE {
       wikibase:grammaticalFeature wd:Q1775415, wd:Q146786, wd:Q72249355 .
   }
 
-  # Maculine
+  # Masculine
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineInanimateSingularActiveParticipleForm .
@@ -94,19 +94,19 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?imperativeFirstPersonPluralForm .
     ?imperativeFirstPersonPluralForm ontolex:representation ?imperativeFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q22716 .
+      wikibase:grammaticalFeature wd:Q22716, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?imperativeSecondPersonSingularForm .
     ?imperativeSecondPersonSingularForm ontolex:representation ?imperativeSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q22716 .
+      wikibase:grammaticalFeature wd:Q22716, wd:Q51929049, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?imperativeSecondPersonPluralForm .
     ?imperativeSecondPersonPluralForm ontolex:representation ?imperativeSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q22716 .
+      wikibase:grammaticalFeature wd:Q22716, wd:Q51929049, wd:Q146786 .
   }
 
   # MARK: Indicative Present
@@ -114,36 +114,36 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentFirstPersonSingularForm .
     ?indicativePresentFirstPersonSingularForm ontolex:representation ?indicativePresentFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q21714344, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentFirstPersonPluralForm .
     ?indicativePresentFirstPersonPluralForm ontolex:representation ?indicativePresentFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentSecondPersonSingularForm .
     ?indicativePresentSecondPersonSingularForm ontolex:representation ?indicativePresentSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929049, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentSecondPersonPluralForm .
     ?indicativePresentSecondPersonPluralForm ontolex:representation ?indicativePresentSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929049, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentThirdPersonSingularForm .
     ?indicativePresentThirdPersonSingularForm ontolex:representation ?indicativePresentThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentThirdPersonPluralForm .
     ?indicativePresentThirdPersonPluralForm ontolex:representation ?indicativePresentThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929074, wd:Q146786 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/czech/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/czech/verbs/query_verbs_2.sparql
@@ -36,13 +36,13 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?femininePastTransgressiveSingularForm .
     ?femininePastTransgressiveSingularForm ontolex:representation ?femininePastTransgressiveSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110786, wd:Q12750232 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q12750232, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?femininePastTransgressivePluralForm .
     ?femininePastTransgressivePluralForm ontolex:representation ?femininePastTransgressivePlural ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q146786, wd:Q12750232 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q12750232, wd:Q146786 .
   }
 
   OPTIONAL {
@@ -57,18 +57,17 @@ WHERE {
       wikibase:grammaticalFeature wd:Q1775415, wd:Q146786, wd:Q72249544 .
   }
 
-  # Masculine
-
+  # Masculine Inanimate
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineInanimatePastTransgressiveSingularForm .
     ?masculineInanimatePastTransgressiveSingularForm ontolex:representation ?masculineInanimatePastTransgressiveSingular ;
-      wikibase:grammaticalFeature wd:Q52943434, wd:Q110786, wd:Q12750232 .
+      wikibase:grammaticalFeature wd:Q52943434, wd:Q12750232, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineInanimatePastTransgressivePluralForm .
     ?masculineInanimatePastTransgressivePluralForm ontolex:representation ?masculineInanimatePastTransgressivePlural ;
-      wikibase:grammaticalFeature wd:Q52943434, wd:Q146786, wd:Q12750232 .
+      wikibase:grammaticalFeature wd:Q52943434, wd:Q12750232, wd:Q146786 .
   }
 
   OPTIONAL {
@@ -83,16 +82,17 @@ WHERE {
       wikibase:grammaticalFeature wd:Q52943434, wd:Q146786, wd:Q72249544 .
   }
 
+  # Masculine Animate
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineAnimatePastTransgressiveSingularForm .
     ?masculineAnimatePastTransgressiveSingularForm ontolex:representation ?masculineAnimatePastTransgressiveSingular ;
-      wikibase:grammaticalFeature wd:Q54020116, wd:Q110786, wd:Q12750232 .
+      wikibase:grammaticalFeature wd:Q54020116, wd:Q12750232, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineAnimatePastTransgressivePluralForm .
     ?masculineAnimatePastTransgressivePluralForm ontolex:representation ?masculineAnimatePastTransgressivePlural ;
-      wikibase:grammaticalFeature wd:Q54020116, wd:Q146786, wd:Q12750232 .
+      wikibase:grammaticalFeature wd:Q54020116, wd:Q12750232, wd:Q146786 .
   }
 
   OPTIONAL {
@@ -108,21 +108,19 @@ WHERE {
   }
 
   # Neuter
-
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?neuterPastTransgressiveSingularForm .
     ?neuterPastTransgressiveSingularForm ontolex:representation ?neuterPastTransgressiveSingular ;
-      wikibase:grammaticalFeature wd:Q1775461, wd:Q110786, wd:Q12750232 .
+      wikibase:grammaticalFeature wd:Q1775461, wd:Q12750232, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?neuterPastTransgressivePluralForm .
     ?neuterPastTransgressivePluralForm ontolex:representation ?neuterPastTransgressivePlural ;
-      wikibase:grammaticalFeature wd:Q1775461, wd:Q146786, wd:Q12750232 .
+      wikibase:grammaticalFeature wd:Q1775461, wd:Q12750232, wd:Q146786 .
   }
 
-  # MARK: Passive Participle
-
+  # Passive Participle
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?neuterSingularPassiveParticipleForm .
     ?neuterSingularPassiveParticipleForm ontolex:representation ?neuterSingularPassiveParticiple ;

--- a/src/scribe_data/wikidata/language_data_extraction/danish/adjectives/query_adjectives_1.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/danish/adjectives/query_adjectives_1.sparql
@@ -18,12 +18,12 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?commonIndefiniteSingularPositiveForm .
     ?commonIndefiniteSingularPositiveForm ontolex:representation ?commonIndefiniteSingularPositive ;
-      wikibase:grammaticalFeature wd:Q1305037, wd:Q110786, wd:Q53997857, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q1305037, wd:Q53997857, wd:Q110786, wd:Q3482678 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?neuterIndefiniteSingularPositiveForm .
     ?neuterIndefiniteSingularPositiveForm ontolex:representation ?neuterIndefiniteSingularPositive ;
-      wikibase:grammaticalFeature wd:Q1775461, wd:Q110786, wd:Q53997857, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q1775461, wd:Q53997857, wd:Q110786, wd:Q3482678 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/danish/adjectives/query_adjectives_2.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/danish/adjectives/query_adjectives_2.sparql
@@ -33,6 +33,6 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?definiteSingularPositiveForm .
     ?definiteSingularPositiveForm ontolex:representation ?definiteSingularPositive ;
-      wikibase:grammaticalFeature wd:Q110786, wd:Q53997851, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q53997851, wd:Q110786, wd:Q3482678 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/danish/adjectives/query_adjectives_3.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/danish/adjectives/query_adjectives_3.sparql
@@ -25,12 +25,12 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indefiniteSingularSuperlativeForm .
     ?indefiniteSingularSuperlativeForm ontolex:representation ?indefiniteSingularSuperlative ;
-      wikibase:grammaticalFeature wd:Q110786, wd:Q53997857, wd:Q1817208 .
+      wikibase:grammaticalFeature wd:Q53997857, wd:Q110786, wd:Q1817208 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?definiteSingularSuperlativeForm .
     ?definiteSingularSuperlativeForm ontolex:representation ?definiteSingularSuperlative ;
-      wikibase:grammaticalFeature wd:Q110786, wd:Q53997851, wd:Q1817208 .
+      wikibase:grammaticalFeature wd:Q53997851, wd:Q110786, wd:Q1817208 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/danish/verbs/query_verbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/danish/verbs/query_verbs.sparql
@@ -51,19 +51,19 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?passiveInfinitiveForm .
     ?passiveInfinitiveForm ontolex:representation ?passiveInfinitive ;
-      wikibase:grammaticalFeature wd:Q179230, wd:Q1194697 .
+      wikibase:grammaticalFeature wd:Q1194697, wd:Q179230 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?passivePresentForm .
     ?passivePresentForm ontolex:representation ?passivePresent ;
-      wikibase:grammaticalFeature wd:Q192613, wd:Q1194697 .
+      wikibase:grammaticalFeature wd:Q1194697, wd:Q192613 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?passivePreteriteForm .
     ?passivePreteriteForm ontolex:representation ?passivePreterite ;
-      wikibase:grammaticalFeature wd:Q442485, wd:Q1194697 .
+      wikibase:grammaticalFeature wd:Q1194697, wd:Q442485 .
   }
 
   # MARK: Active
@@ -71,18 +71,18 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?activeInfinitiveForm .
     ?activeInfinitiveForm ontolex:representation ?activeInfinitive ;
-      wikibase:grammaticalFeature wd:Q179230, wd:Q1317831 .
+      wikibase:grammaticalFeature wd:Q1317831, wd:Q179230 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?activePresentForm .
     ?activePresentForm ontolex:representation ?activePresent ;
-      wikibase:grammaticalFeature wd:Q192613, wd:Q1317831 .
+      wikibase:grammaticalFeature wd:Q1317831, wd:Q192613 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?activePreteriteForm .
     ?activePreteriteForm ontolex:representation ?activePreterite ;
-      wikibase:grammaticalFeature wd:Q442485, wd:Q1317831 .
+      wikibase:grammaticalFeature wd:Q1317831, wd:Q442485 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/english/verbs/query_verbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/english/verbs/query_verbs.sparql
@@ -68,7 +68,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?simplePresentThirdPersonSingularForm .
     ?simplePresentThirdPersonSingularForm ontolex:representation ?simplePresentThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q3910936 .
+      wikibase:grammaticalFeature wd:Q3910936, wd:Q51929074, wd:Q110786 .
       FILTER NOT EXISTS { ?simplePresentThirdPersonSingularForm wdt:P6191 wd:Q181970 . }
       FILTER NOT EXISTS { ?simplePresentThirdPersonSingularForm wikibase:grammaticalFeature wd:Q126473 . }
       FILTER(LANG(?simplePresentThirdPersonSingular) = "en")

--- a/src/scribe_data/wikidata/language_data_extraction/esperanto/verbs/query_verbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/esperanto/verbs/query_verbs.sparql
@@ -41,7 +41,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentForm .
     ?indicativePresentForm ontolex:representation ?indicativePresent ;
-      wikibase:grammaticalFeature wd:Q192613, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613 .
       FILTER(LANG(?indicativePresent) = "eo")
   }
 
@@ -50,7 +50,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePastForm .
     ?indicativePastForm ontolex:representation ?indicativePast ;
-      wikibase:grammaticalFeature wd:Q1994301, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q1994301 .
       FILTER(LANG(?indicativePast) = "eo")
   }
 
@@ -59,7 +59,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeFutureForm .
     ?indicativeFutureForm ontolex:representation ?indicativeFuture ;
-      wikibase:grammaticalFeature wd:Q501405, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q501405 .
       FILTER(LANG(?indicativeFuture) = "eo")
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/french/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/french/verbs/query_verbs_1.sparql
@@ -30,37 +30,37 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentFirstPersonSingularForm .
     ?indicativePresentFirstPersonSingularForm ontolex:representation ?indicativePresentFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q21714344, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentFirstPersonPluralForm .
     ?indicativePresentFirstPersonPluralForm ontolex:representation ?indicativePresentFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentSecondPersonSingularForm .
     ?indicativePresentSecondPersonSingularForm ontolex:representation ?indicativePresentSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929049, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentSecondPersonPluralForm .
     ?indicativePresentSecondPersonPluralForm ontolex:representation ?indicativePresentSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929049, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentThirdPersonSingularForm .
     ?indicativePresentThirdPersonSingularForm ontolex:representation ?indicativePresentThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentThirdPersonPluralForm .
     ?indicativePresentThirdPersonPluralForm ontolex:representation ?indicativePresentThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929074, wd:Q146786 .
   }
 
   # MARK: Indicative Preterite
@@ -68,36 +68,36 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePreteriteFirstPersonSingularForm .
     ?indicativePreteriteFirstPersonSingularForm ontolex:representation ?indicativePreteriteFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q682111, wd:Q442485 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q442485, wd:Q21714344, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePreteriteFirstPersonPluralForm .
     ?indicativePreteriteFirstPersonPluralForm ontolex:representation ?indicativePreteriteFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q682111, wd:Q442485 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q442485, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePreteriteSecondPersonSingularForm .
     ?indicativePreteriteSecondPersonSingularForm ontolex:representation ?indicativePreteriteSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q682111, wd:Q442485 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q442485, wd:Q51929049, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePreteriteSecondPersonPluralForm .
     ?indicativePreteriteSecondPersonPluralForm ontolex:representation ?indicativePreteriteSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q682111, wd:Q442485 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q442485, wd:Q51929049, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePreteriteThirdPersonSingularForm .
     ?indicativePreteriteThirdPersonSingularForm ontolex:representation ?indicativePreteriteThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q682111, wd:Q442485 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q442485, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePreteriteThirdPersonPluralForm .
     ?indicativePreteriteThirdPersonPluralForm ontolex:representation ?indicativePreteriteThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q682111, wd:Q442485 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q442485, wd:Q51929074, wd:Q146786 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/french/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/french/verbs/query_verbs_2.sparql
@@ -30,37 +30,37 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeSimpleFutureFirstPersonSingularForm .
     ?indicativeSimpleFutureFirstPersonSingularForm ontolex:representation ?indicativeSimpleFutureFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q682111, wd:Q1475560 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q1475560, wd:Q21714344, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeSimpleFutureFirstPersonPluralForm .
     ?indicativeSimpleFutureFirstPersonPluralForm ontolex:representation ?indicativeSimpleFutureFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q682111, wd:Q1475560 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q1475560, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeSimpleFutureSecondPersonSingularForm .
     ?indicativeSimpleFutureSecondPersonSingularForm ontolex:representation ?indicativeSimpleFutureSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q682111, wd:Q1475560 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q1475560, wd:Q51929049, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeSimpleFutureSecondPersonPluralForm .
     ?indicativeSimpleFutureSecondPersonPluralForm ontolex:representation ?indicativeSimpleFutureSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q682111, wd:Q1475560 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q1475560, wd:Q51929049, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeSimpleFutureThirdPersonSingularForm .
-    ?indicativeSimpleFutureThirdPersonSingularForm ontolex:representation ?indicativeSimpleFutureThirdPersonSingular  ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q682111, wd:Q1475560 .
+    ?indicativeSimpleFutureThirdPersonSingularForm ontolex:representation ?indicativeSimpleFutureThirdPersonSingular ;
+      wikibase:grammaticalFeature wd:Q682111, wd:Q1475560, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeSimpleFutureThirdPersonPluralForm .
     ?indicativeSimpleFutureThirdPersonPluralForm ontolex:representation ?indicativeSimpleFutureThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q682111, wd:Q1475560 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q1475560, wd:Q51929074, wd:Q146786 .
   }
 
   # MARK: Imperfect
@@ -68,36 +68,36 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeImperfectFirstPersonSingularForm .
     ?indicativeImperfectFirstPersonSingularForm ontolex:representation ?indicativeImperfectFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q682111, wd:Q108524486 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q108524486, wd:Q21714344, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeImperfectFirstPersonPluralForm .
     ?indicativeImperfectFirstPersonPluralForm ontolex:representation ?indicativeImperfectFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q682111, wd:Q108524486 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q108524486, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeImperfectSecondPersonSingularForm .
     ?indicativeImperfectSecondPersonSingularForm ontolex:representation ?indicativeImperfectSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q682111, wd:Q108524486 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q108524486, wd:Q51929049, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeImperfectSecondPersonPluralForm .
     ?indicativeImperfectSecondPersonPluralForm ontolex:representation ?indicativeImperfectSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q682111, wd:Q108524486 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q108524486, wd:Q51929049, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeImperfectThirdPersonSingularForm .
     ?indicativeImperfectThirdPersonSingularForm ontolex:representation ?indicativeImperfectThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q682111, wd:Q108524486 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q108524486, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeImperfectThirdPersonPluralForm .
     ?indicativeImperfectThirdPersonPluralForm ontolex:representation ?indicativeImperfectThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q682111, wd:Q108524486 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q108524486, wd:Q51929074, wd:Q146786 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/german/nouns/query_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/german/nouns/query_nouns.sparql
@@ -18,7 +18,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativePluralForm .
     ?nominativePluralForm ontolex:representation ?nominativePlural ;
-      wikibase:grammaticalFeature wd:Q146786, wd:Q131105 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q146786 .
   }
 
   # MARK: Gender(s)

--- a/src/scribe_data/wikidata/language_data_extraction/german/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/german/verbs/query_verbs_1.sparql
@@ -23,37 +23,37 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentFirstPersonSingularForm .
     ?indicativePresentFirstPersonSingularForm ontolex:representation ?indicativePresentFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q21714344, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentFirstPersonPluralForm .
     ?indicativePresentFirstPersonPluralForm ontolex:representation ?indicativePresentFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentSecondPersonSingularForm .
     ?indicativePresentSecondPersonSingularForm ontolex:representation ?indicativePresentSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929049, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentSecondPersonPluralForm .
     ?indicativePresentSecondPersonPluralForm ontolex:representation ?indicativePresentSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929049, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentThirdPersonSingularForm .
     ?indicativePresentThirdPersonSingularForm ontolex:representation ?indicativePresentThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentThirdPersonPluralForm .
     ?indicativePresentThirdPersonPluralForm ontolex:representation ?indicativePresentThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929074, wd:Q146786 .
   }
 
   SERVICE wikibase:label {

--- a/src/scribe_data/wikidata/language_data_extraction/german/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/german/verbs/query_verbs_2.sparql
@@ -33,35 +33,37 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePreteriteFirstPersonSingularForm .
     ?indicativePreteriteFirstPersonSingularForm ontolex:representation ?indicativePreteriteFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q682111, wd:Q442485 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q442485, wd:Q21714344, wd:Q110786 .
   }
+
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePreteriteFirstPersonPluralForm .
     ?indicativePreteriteFirstPersonPluralForm ontolex:representation ?indicativePreteriteFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q682111, wd:Q442485 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q442485, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePreteriteSecondPersonSingularForm .
     ?indicativePreteriteSecondPersonSingularForm ontolex:representation ?indicativePreteriteSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q682111, wd:Q442485 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q442485, wd:Q51929049, wd:Q110786 .
   }
+
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePreteriteSecondPersonPluralForm .
     ?indicativePreteriteSecondPersonPluralForm ontolex:representation ?indicativePreteriteSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q682111, wd:Q442485 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q442485, wd:Q51929049, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePreteriteThirdPersonSingularForm .
     ?indicativePreteriteThirdPersonSingularForm ontolex:representation ?indicativePreteriteThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q682111, wd:Q442485 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q442485, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePreteriteThirdPersonPluralForm .
     ?indicativePreteriteThirdPersonPluralForm ontolex:representation ?indicativePreteriteThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q682111, wd:Q442485 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q442485, wd:Q51929074, wd:Q146786 .
   }
 
   # MARK: Auxiliary Verb(s)

--- a/src/scribe_data/wikidata/language_data_extraction/greek/verbs/query_verbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/greek/verbs/query_verbs.sparql
@@ -22,36 +22,36 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presentFirstPersonSingularForm .
     ?presentFirstPersonSingularForm ontolex:representation ?presentFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q192613, wd:Q21714344, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presentFirstPersonPluralForm .
     ?presentFirstPersonPluralForm ontolex:representation ?presentFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q192613, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presentSecondPersonSingularForm .
     ?presentSecondPersonSingularForm ontolex:representation ?presentSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q192613, wd:Q51929049, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presentSecondPersonPluralForm .
     ?presentSecondPersonPluralForm ontolex:representation ?presentSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q192613, wd:Q51929049, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presentThirdPersonSingularForm .
     ?presentThirdPersonSingularForm ontolex:representation ?presentThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q192613, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presentThirdPersonPluralForm .
     ?presentThirdPersonPluralForm ontolex:representation ?presentThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q192613, wd:Q51929074, wd:Q146786 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/hebrew/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hebrew/verbs/query_verbs_1.sparql
@@ -21,28 +21,28 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?femininePresentSingularForm .
     ?femininePresentSingularForm ontolex:representation ?femininePresentSingular ;
-      wikibase:grammaticalFeature wd:Q110786, wd:Q192613, wd:Q1775415 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q192613, wd:Q110786 .
       FILTER(lang(?femininePresentSingular) = "he")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?femininePresentPluralForm .
     ?femininePresentPluralForm ontolex:representation ?femininePresentPlural ;
-      wikibase:grammaticalFeature wd:Q146786, wd:Q192613, wd:Q1775415 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q192613, wd:Q146786 .
       FILTER(lang(?femininePresentPlural) = "he")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculinePresentSingularForm .
     ?masculinePresentSingularForm ontolex:representation ?masculinePresentSingular ;
-      wikibase:grammaticalFeature wd:Q110786, wd:Q192613, wd:Q499327 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q192613, wd:Q110786 .
       FILTER(lang(?masculinePresentSingular) = "he")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculinePresentPluralForm .
     ?masculinePresentPluralForm ontolex:representation ?masculinePresentPlural ;
-      wikibase:grammaticalFeature wd:Q146786, wd:Q192613, wd:Q499327 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q192613, wd:Q146786 .
       FILTER(lang(?masculinePresentPlural) = "he")
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/hebrew/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hebrew/verbs/query_verbs_2.sparql
@@ -18,28 +18,28 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?feminineImperativeSecondPersonSingularForm .
     ?feminineImperativeSecondPersonSingularForm ontolex:representation ?feminineImperativeSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q22716, wd:Q1775415 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q22716, wd:Q51929049, wd:Q110786 .
       FILTER(lang(?feminineImperativeSecondPersonSingular) = "he")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?feminineImperativeSecondPersonPluralForm .
     ?feminineImperativeSecondPersonPluralForm ontolex:representation ?feminineImperativeSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q22716, wd:Q1775415 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q22716, wd:Q51929049, wd:Q146786 .
       FILTER(lang(?feminineImperativeSecondPersonPlural) = "he")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineImperativeSecondPersonSingularForm .
     ?masculineImperativeSecondPersonSingularForm ontolex:representation ?masculineImperativeSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q22716, wd:Q499327 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q22716, wd:Q51929049, wd:Q110786 .
       FILTER(lang(?masculineImperativeSecondPersonSingular) = "he")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineImperativeSecondPersonPluralForm .
     ?masculineImperativeSecondPersonPluralForm ontolex:representation ?masculineImperativeSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q22716, wd:Q499327 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q22716, wd:Q51929049, wd:Q146786 .
       FILTER(lang(?masculineImperativeSecondPersonPlural) = "he")
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/hebrew/verbs/query_verbs_3.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hebrew/verbs/query_verbs_3.sparql
@@ -23,17 +23,17 @@ WHERE {
 
   # MARK: Past
 
-  OPTIONAL {
+ OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pastFirstPersonSingular .
     ?pastFirstPersonSingular ontolex:representation ?pastFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q1994301 .
+      wikibase:grammaticalFeature wd:Q1994301, wd:Q21714344, wd:Q110786 .
       FILTER(lang(?pastTPP) = "he")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pastFirstPersonPluralForm .
     ?pastFirstPersonPluralForm ontolex:representation ?pastFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q1994301 .
+      wikibase:grammaticalFeature wd:Q1994301, wd:Q21714344, wd:Q146786 .
       FILTER(lang(?pastFirstPersonPlural) = "he")
   }
 
@@ -42,28 +42,28 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?femininePastSecondPersonSingularForm .
     ?femininePastSecondPersonSingularForm ontolex:representation ?femininePastSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q1994301, wd:Q1775415 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q1994301, wd:Q51929049, wd:Q110786 .
       FILTER(lang(?femininePastSecondPersonSingular) = "he")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?femininePastSecondPersonPluralForm .
     ?femininePastSecondPersonPluralForm ontolex:representation ?femininePastSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q1994301, wd:Q1775415 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q1994301, wd:Q51929049, wd:Q146786 .
       FILTER(lang(?femininePastSecondPersonPlural) = "he")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?femininePastThirdPersonSingularForm .
     ?femininePastThirdPersonSingularForm ontolex:representation ?femininePastThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q1994301, wd:Q1775415 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q1994301, wd:Q51929074, wd:Q110786 .
       FILTER(lang(?femininePastThirdPersonSingular) = "he")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?femininePastThirdPersonPluralForm .
     ?femininePastThirdPersonPluralForm ontolex:representation ?femininePastThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q1994301, wd:Q1775415 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q1994301, wd:Q51929074, wd:Q146786 .
       FILTER(lang(?femininePastThirdPersonPlural) = "he")
   }
 
@@ -72,28 +72,28 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculinePastSecondPersonSingularForm .
     ?masculinePastSecondPersonSingularForm ontolex:representation ?masculinePastSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q1994301, wd:Q499327 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q1994301, wd:Q51929049, wd:Q110786 .
       FILTER(lang(?masculinePastSecondPersonSingular) = "he")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculinePastSecondPersonPluralForm .
     ?masculinePastSecondPersonPluralForm ontolex:representation ?masculinePastSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q1994301, wd:Q499327 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q1994301, wd:Q51929049, wd:Q146786 .
       FILTER(lang(?masculinePastSecondPersonPlural) = "he")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculinePastThirdPersonSingularForm .
     ?masculinePastThirdPersonSingularForm ontolex:representation ?masculinePastThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q1994301, wd:Q499327 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q1994301, wd:Q51929074, wd:Q110786 .
       FILTER(lang(?masculinePastThirdPersonSingular) = "he")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculinePastThirdPersonPluralForm .
     ?masculinePastThirdPersonPluralForm ontolex:representation ?masculinePastThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q1994301, wd:Q499327 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q1994301, wd:Q51929074, wd:Q146786 .
       FILTER(lang(?masculinePastThirdPersonPlural) = "he")
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/hebrew/verbs/query_verbs_4.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hebrew/verbs/query_verbs_4.sparql
@@ -26,14 +26,14 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?futureFirstPersonSingularForm .
     ?futureFirstPersonSingularForm ontolex:representation ?futureFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q501405 .
-      FILTER(lang(?futureFirstPersonSingular) = "he") .
+      wikibase:grammaticalFeature wd:Q501405, wd:Q21714344, wd:Q110786 .
+    FILTER(lang(?futureFirstPersonSingular) = "he") .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?futureFirstPersonPluralForm .
     ?futureFirstPersonPluralForm ontolex:representation ?futureFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q501405 .
+      wikibase:grammaticalFeature wd:Q501405, wd:Q21714344, wd:Q146786 .
       FILTER(lang(?futureFirstPersonPlural) = "he") .
   }
 
@@ -42,28 +42,28 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?feminineFutureSecondPersonSingularForm .
     ?feminineFutureSecondPersonSingularForm ontolex:representation ?feminineFutureSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q501405, wd:Q1775415 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q501405, wd:Q51929049, wd:Q110786 .
       FILTER(lang(?feminineFutureSecondPersonSingular) = "he") .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?feminineFutureSecondPersonPluralForm .
     ?feminineFutureSecondPersonPluralForm ontolex:representation ?feminineFutureSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q501405, wd:Q1775415 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q501405, wd:Q51929049, wd:Q146786 .
       FILTER(lang(?feminineFutureSecondPersonPlural) = "he") .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?feminineFutureThirdPersonSingularForm .
     ?feminineFutureThirdPersonSingularForm ontolex:representation ?feminineFutureThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q501405, wd:Q1775415 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q501405, wd:Q51929074, wd:Q110786 .
       FILTER(lang(?feminineFutureThirdPersonSingular) = "he") .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?feminineFutureThirdPersonPluralForm .
     ?feminineFutureThirdPersonPluralForm ontolex:representation ?feminineFutureThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q501405, wd:Q1775415 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q501405, wd:Q51929074, wd:Q146786 .
       FILTER(lang(?feminineFutureThirdPersonPlural) = "he") .
   }
 
@@ -72,28 +72,28 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineFutureSecondPersonSingularForm .
     ?masculineFutureSecondPersonSingularForm ontolex:representation ?masculineFutureSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q501405, wd:Q499327 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q501405, wd:Q51929049, wd:Q110786 .
       FILTER(lang(?masculineFutureSecondPersonSingular) = "he") .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineFutureSecondPersonPluralForm .
     ?masculineFutureSecondPersonPluralForm ontolex:representation ?masculineFutureSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q501405, wd:Q499327 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q501405, wd:Q51929049, wd:Q146786 .
       FILTER(lang(?masculineFutureSecondPersonPlural) = "he") .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineFutureThirdPersonSingularForm .
     ?masculineFutureThirdPersonSingularForm ontolex:representation ?masculineFutureThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q501405, wd:Q499327 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q501405, wd:Q51929074, wd:Q110786 .
       FILTER(lang(?masculineFutureThirdPersonSingular) = "he") .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineFutureThirdPersonPluralForm .
     ?masculineFutureThirdPersonPluralForm ontolex:representation ?masculineFutureThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q501405, wd:Q499327 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q501405, wd:Q51929074, wd:Q146786 .
       FILTER(lang(?masculineFutureThirdPersonPlural) = "he") .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/hindi/adjectives/query_adjectives.sparql
@@ -49,93 +49,93 @@ WHERE {
       FILTER(LANG(?plural) = "hi")
   }
 
-  # MARK: Vocative
+  # Vocative
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?vocativeFeminineSingularForm .
     ?vocativeFeminineSingularForm ontolex:representation ?vocativeFeminineSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110786, wd:Q185077 .
+      wikibase:grammaticalFeature wd:Q185077, wd:Q1775415, wd:Q110786 .
       FILTER(LANG(?vocativeFeminineSingular) = "hi")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?vocativeFemininePluralForm .
     ?vocativeFemininePluralForm ontolex:representation ?vocativeFemininePlural ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q146786, wd:Q185077 .
+      wikibase:grammaticalFeature wd:Q185077, wd:Q1775415, wd:Q146786 .
       FILTER(LANG(?vocativeFemininePlural) = "hi")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?vocativeMasculineSingularForm .
     ?vocativeMasculineSingularForm ontolex:representation ?vocativeMasculineSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110786, wd:Q185077 .
+      wikibase:grammaticalFeature wd:Q185077, wd:Q499327, wd:Q110786 .
       FILTER(LANG(?vocativeMasculineSingular) = "hi")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?vocativeMasculinePluralForm .
     ?vocativeMasculinePluralForm ontolex:representation ?vocativeMasculinePlural ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q146786, wd:Q185077 .
+      wikibase:grammaticalFeature wd:Q185077, wd:Q499327, wd:Q146786 .
       FILTER(LANG(?vocativeMasculinePlural) = "hi")
   }
 
-  # MARK: Direct
+  # Direct
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?directFeminineSingularForm .
     ?directFeminineSingularForm ontolex:representation ?directFeminineSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110786, wd:Q1751855 .
+      wikibase:grammaticalFeature wd:Q1751855, wd:Q1775415, wd:Q110786 .
       FILTER(LANG(?directFeminineSingular) = "hi")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?directFemininePluralForm .
     ?directFemininePluralForm ontolex:representation ?directFemininePlural ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q146786, wd:Q1751855 .
+      wikibase:grammaticalFeature wd:Q1751855, wd:Q1775415, wd:Q146786 .
       FILTER(LANG(?directFemininePlural) = "hi")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?directMasculineSingularForm .
     ?directMasculineSingularForm ontolex:representation ?directMasculineSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110786, wd:Q1751855 .
+      wikibase:grammaticalFeature wd:Q1751855, wd:Q499327, wd:Q110786 .
       FILTER(LANG(?directMasculineSingular) = "hi")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?directMasculinePluralForm .
     ?directMasculinePluralForm ontolex:representation ?directMasculinePlural ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q146786, wd:Q1751855 .
+      wikibase:grammaticalFeature wd:Q1751855, wd:Q499327, wd:Q146786 .
       FILTER(LANG(?directMasculinePlural) = "hi")
   }
 
-  # MARK: Oblique
+  # Oblique
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?obliqueFeminineSingularForm .
     ?obliqueFeminineSingularForm ontolex:representation ?obliqueFeminineSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110786, wd:Q1233197 .
+      wikibase:grammaticalFeature wd:Q1233197, wd:Q1775415, wd:Q110786 .
       FILTER(LANG(?obliqueFeminineSingular) = "hi")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?obliqueFemininePluralForm .
     ?obliqueFemininePluralForm ontolex:representation ?obliqueFemininePlural ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q146786, wd:Q1233197 .
+      wikibase:grammaticalFeature wd:Q1233197, wd:Q1775415, wd:Q146786 .
       FILTER(LANG(?obliqueFemininePlural) = "hi")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?obliqueMasculineSingularForm .
     ?obliqueMasculineSingularForm ontolex:representation ?obliqueMasculineSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110786, wd:Q1233197 .
+      wikibase:grammaticalFeature wd:Q1233197, wd:Q499327, wd:Q110786 .
       FILTER(LANG(?obliqueMasculineSingular) = "hi")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?obliqueMasculinePluralForm .
     ?obliqueMasculinePluralForm ontolex:representation ?obliqueMasculinePlural ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q146786, wd:Q1233197 .
+      wikibase:grammaticalFeature wd:Q1233197, wd:Q499327, wd:Q146786 .
       FILTER(LANG(?obliqueMasculinePlural) = "hi")
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/hindustani/urdu/adjectives/query_adjectives.sparql
@@ -51,28 +51,28 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?vocativeFeminineSingularForm .
     ?vocativeFeminineSingularForm ontolex:representation ?vocativeFeminineSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110786, wd:Q185077 .
+      wikibase:grammaticalFeature wd:Q185077, wd:Q1775415, wd:Q110786 .
       FILTER(LANG(?vocativeFeminineSingular) = "ur")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?vocativeFemininePluralForm .
     ?vocativeFemininePluralForm ontolex:representation ?vocativeFemininePlural ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q146786, wd:Q185077 .
+      wikibase:grammaticalFeature wd:Q185077, wd:Q1775415, wd:Q146786 .
       FILTER(LANG(?vocativeFemininePlural) = "ur")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?vocativeMasculineSingularForm .
     ?vocativeMasculineSingularForm ontolex:representation ?vocativeMasculineSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110786, wd:Q185077 .
+      wikibase:grammaticalFeature wd:Q185077, wd:Q499327, wd:Q110786 .
       FILTER(LANG(?vocativeMasculineSingular) = "ur")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?vocativeMasculinePluralForm .
     ?vocativeMasculinePluralForm ontolex:representation ?vocativeMasculinePlural ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q146786, wd:Q185077 .
+      wikibase:grammaticalFeature wd:Q185077, wd:Q499327, wd:Q146786 .
       FILTER(LANG(?vocativeMasculinePlural) = "ur")
   }
 
@@ -81,28 +81,28 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?directFeminineSingularForm .
     ?directFeminineSingularForm ontolex:representation ?directFeminineSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110786, wd:Q1751855 .
+      wikibase:grammaticalFeature wd:Q1751855, wd:Q1775415, wd:Q110786 .
       FILTER(LANG(?directFeminineSingular) = "ur")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?directFemininePluralForm .
     ?directFemininePluralForm ontolex:representation ?directFemininePlural ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q146786, wd:Q1751855 .
+      wikibase:grammaticalFeature wd:Q1751855, wd:Q1775415, wd:Q146786 .
       FILTER(LANG(?directFemininePlural) = "ur")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?directMasculineSingularForm .
     ?directMasculineSingularForm ontolex:representation ?directMasculineSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110786, wd:Q1751855 .
+      wikibase:grammaticalFeature wd:Q1751855, wd:Q499327, wd:Q110786 .
       FILTER(LANG(?directMasculineSingular) = "ur")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?directMasculinePluralForm .
     ?directMasculinePluralForm ontolex:representation ?directMasculinePlural ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q146786, wd:Q1751855 .
+      wikibase:grammaticalFeature wd:Q1751855, wd:Q499327, wd:Q146786 .
       FILTER(LANG(?directMasculinePlural) = "ur")
   }
 
@@ -111,28 +111,28 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?obliqueFeminineSingularForm .
     ?obliqueFeminineSingularForm ontolex:representation ?obliqueFeminineSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110786, wd:Q1233197 .
+      wikibase:grammaticalFeature wd:Q1233197, wd:Q1775415, wd:Q110786 .
       FILTER(LANG(?obliqueFeminineSingular) = "ur")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?obliqueFemininePluralForm .
     ?obliqueFemininePluralForm ontolex:representation ?obliqueFemininePlural ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q146786, wd:Q1233197 .
+      wikibase:grammaticalFeature wd:Q1233197, wd:Q1775415, wd:Q146786 .
       FILTER(LANG(?obliqueFemininePlural) = "ur")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?obliqueMasculineSingularForm .
     ?obliqueMasculineSingularForm ontolex:representation ?obliqueMasculineSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110786, wd:Q1233197 .
+      wikibase:grammaticalFeature wd:Q1233197, wd:Q499327, wd:Q110786 .
       FILTER(LANG(?obliqueMasculineSingular) = "ur")
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?obliqueMasculinePluralForm .
     ?obliqueMasculinePluralForm ontolex:representation ?obliqueMasculinePlural ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q146786, wd:Q1233197 .
+      wikibase:grammaticalFeature wd:Q1233197, wd:Q499327, wd:Q146786 .
       FILTER(LANG(?obliqueMasculinePlural) = "ur")
   }
-}
+  }

--- a/src/scribe_data/wikidata/language_data_extraction/norwegian/bokmål/nouns/query_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/norwegian/bokmål/nouns/query_nouns.sparql
@@ -22,7 +22,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indefinitePluralForm .
     ?indefinitePluralForm ontolex:representation ?indefinitePlural ;
-      wikibase:grammaticalFeature wd:Q146786, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q53997857, wd:Q146786 .
   }
 
   # MARK: Definite Singular
@@ -30,7 +30,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?definiteSingularForm .
     ?definiteSingularForm ontolex:representation ?definiteSingular ;
-      wikibase:grammaticalFeature wd:Q110786, wd:Q53997851 .
+      wikibase:grammaticalFeature wd:Q53997851, wd:Q110786 .
   }
 
   # MARK: Definite Plural
@@ -38,7 +38,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?definitePluralForm .
     ?definitePluralForm ontolex:representation ?definitePlural ;
-      wikibase:grammaticalFeature wd:Q146786, wd:Q53997851 .
+      wikibase:grammaticalFeature wd:Q53997851, wd:Q146786 .
   }
 
   # MARK: Gender(s)

--- a/src/scribe_data/wikidata/language_data_extraction/norwegian/bokmål/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/norwegian/bokmål/verbs/query_verbs_2.sparql
@@ -27,19 +27,19 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pluralPastParticipleForm .
     ?pluralPastParticipleForm ontolex:representation ?pluralPastParticiple ;
-      wikibase:grammaticalFeature wd:Q12717679, wd:Q146786 .
+      wikibase:grammaticalFeature wd:Q146786, wd:Q12717679 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?definiteSingularPastParticipleForm .
     ?definiteSingularPastParticipleForm ontolex:representation ?definiteSingularPastParticiple ;
-      wikibase:grammaticalFeature wd:Q12717679, wd:Q110786, wd:Q53997851 .
+      wikibase:grammaticalFeature wd:Q53997851, wd:Q110786, wd:Q12717679 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?neuterIndefiniteSingularPastParticipleForm .
     ?neuterIndefiniteSingularPastParticipleForm ontolex:representation ?neuterIndefiniteSingularPastParticiple ;
-      wikibase:grammaticalFeature wd:Q12717679, wd:Q1775461, wd:Q110786, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q1775461, wd:Q53997857, wd:Q110786, wd:Q12717679 .
   }
 
   OPTIONAL {

--- a/src/scribe_data/wikidata/language_data_extraction/norwegian/nynorsk/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/norwegian/nynorsk/adjectives/query_adjectives.sparql
@@ -30,7 +30,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?definiteSingularForm .
     ?definiteSingularForm ontolex:representation ?definiteSingular ;
-      wikibase:grammaticalFeature wd:Q110786, wd:Q53997851 .
+      wikibase:grammaticalFeature wd:Q53997851, wd:Q110786 .
   }
 
   # MARK: Neuter Indefinite
@@ -38,7 +38,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?neuterIndefiniteSingularForm .
     ?neuterIndefiniteSingularForm ontolex:representation ?neuterIndefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q1775461, wd:Q110786, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q1775461, wd:Q53997857, wd:Q110786 .
   }
 
   # MARK: Common Indefinite
@@ -46,6 +46,6 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?feminineMasculineIndefiniteSingularForm .
     ?feminineMasculineIndefiniteSingularForm ontolex:representation ?feminineMasculineIndefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q499327, wd:Q110786, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q499327, wd:Q53997857, wd:Q110786 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/norwegian/nynorsk/nouns/query_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/norwegian/nynorsk/nouns/query_nouns.sparql
@@ -22,7 +22,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indefinitePluralForm .
     ?indefinitePluralForm ontolex:representation ?indefinitePlural ;
-      wikibase:grammaticalFeature wd:Q146786, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q53997857, wd:Q146786 .
   }
 
   # MARK: Definite Singular
@@ -30,7 +30,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?definiteSingularForm .
     ?definiteSingularForm ontolex:representation ?definiteSingular ;
-      wikibase:grammaticalFeature wd:Q110786, wd:Q53997851 .
+      wikibase:grammaticalFeature wd:Q53997851, wd:Q110786 .
   }
 
   # MARK: Definite Plural
@@ -38,7 +38,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?definitePluralForm .
     ?definitePluralForm ontolex:representation ?definitePlural ;
-      wikibase:grammaticalFeature wd:Q146786, wd:Q53997851 .
+      wikibase:grammaticalFeature wd:Q53997851, wd:Q146786 .
   }
 
   # MARK: Gender(s)

--- a/src/scribe_data/wikidata/language_data_extraction/norwegian/nynorsk/proper_nouns/query_proper_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/norwegian/nynorsk/proper_nouns/query_proper_nouns.sparql
@@ -22,7 +22,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indefinitePluralForm .
     ?indefinitePluralForm ontolex:representation ?indefinitePlural ;
-      wikibase:grammaticalFeature wd:Q146786, wd:Q53997857 .
+      wikibase:grammaticalFeature wd:Q53997857, wd:Q146786 .
   }
 
   # MARK: Definite Singular
@@ -30,7 +30,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?  ?definiteSingularForm .
     ?definiteSingularForm ontolex:representation ?definiteSingular ;
-      wikibase:grammaticalFeature wd:Q110786, wd:Q53997851 .
+      wikibase:grammaticalFeature wd:Q53997851, wd:Q110786 .
   }
 
   # MARK: Definite Plural
@@ -38,7 +38,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?definitePluralForm .
     ?definitePluralForm ontolex:representation ?definitePlural ;
-      wikibase:grammaticalFeature wd:Q146786, wd:Q53997851 .
+      wikibase:grammaticalFeature wd:Q53997851, wd:Q146786 .
   }
 
   # MARK: Gender(s)

--- a/src/scribe_data/wikidata/language_data_extraction/norwegian/nynorsk/verbs/query_verbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/norwegian/nynorsk/verbs/query_verbs.sparql
@@ -67,7 +67,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?passiveInfinitiveForm .
     ?passiveInfinitiveForm ontolex:representation ?passiveInfinitive ;
-      wikibase:grammaticalFeature wd:Q179230, wd:Q1194697 .
+      wikibase:grammaticalFeature wd:Q1194697, wd:Q179230 .
       FILTER(LANG(?passiveInfinitive) = "nn")
   }
 
@@ -76,7 +76,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?passivePresentForm .
     ?passivePresentForm ontolex:representation ?passivePresent ;
-      wikibase:grammaticalFeature wd:Q192613, wd:Q1194697 .
+      wikibase:grammaticalFeature wd:Q1194697, wd:Q192613 .
       FILTER(LANG(?passivePresent) = "nn")
   }
 
@@ -102,7 +102,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?activePresentForm .
     ?activePresentForm ontolex:representation ?activePresent ;
-      wikibase:grammaticalFeature wd:Q192613, wd:Q1317831 .
+      wikibase:grammaticalFeature wd:Q1317831, wd:Q192613 .
       FILTER(LANG(?activePresent) = "nn")
   }
 
@@ -129,7 +129,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?definiteSingularPastParticipleForm .
     ?definiteSingularPastParticipleForm ontolex:representation ?definiteSingularPastParticiple ;
-      wikibase:grammaticalFeature wd:Q110786, wd:Q53997851, wd:Q12717679 .
+      wikibase:grammaticalFeature wd:Q53997851, wd:Q110786, wd:Q12717679 .
       FILTER(LANG(?definiteSingularPastParticiple) = "nn")
   }
 
@@ -138,7 +138,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?neuterIndefiniteSingularPastParticipleForm .
     ?neuterIndefiniteSingularPastParticipleForm ontolex:representation ?neuterIndefiniteSingularPastParticiple ;
-      wikibase:grammaticalFeature wd:Q1775461, wd:Q110786, wd:Q53997857, wd:Q12717679 .
+      wikibase:grammaticalFeature wd:Q1775461, wd:Q53997857, wd:Q110786, wd:Q12717679 .
       FILTER(LANG(?neuterIndefiniteSingularPastParticiple) = "nn")
   }
 
@@ -147,7 +147,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?feminineMasculineIndefiniteSingularPastParticipleForm .
     ?feminineMasculineIndefiniteSingularPastParticipleForm ontolex:representation ?feminineMasculineIndefiniteSingularPastParticiple ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q1775415, wd:Q110786, wd:Q53997857, wd:Q12717679 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q499327, wd:Q53997857, wd:Q110786, wd:Q12717679 .
       FILTER(LANG(?feminineMasculineIndefiniteSingularPastParticiple) = "nn")
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/persian/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/persian/verbs/query_verbs_1.sparql
@@ -27,7 +27,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pastParticipleForm .
     ?pastParticipleForm ontolex:representation ?pastParticiple ;
-      wikibase:grammaticalFeature wd:Q814722, wd:Q1994301 .
+      wikibase:grammaticalFeature wd:Q1994301, wd:Q814722 .
     FILTER(lang(?pastParticiple) = "fa") .
   }
 

--- a/src/scribe_data/wikidata/language_data_extraction/persian/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/persian/verbs/query_verbs_2.sparql
@@ -22,42 +22,42 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeFirstPersonAoristSingularForm .
     ?indicativeFirstPersonAoristSingularForm ontolex:representation ?indicativeFirstPersonAoristSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q682111, wd:Q216497 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q21714344, wd:Q216497, wd:Q110786 .
     FILTER(lang(?indicativeFirstPersonAoristSingular) = "fa") .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeFirstPersonAoristPluralForm .
     ?indicativeFirstPersonAoristPluralForm ontolex:representation ?indicativeFirstPersonAoristPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q682111, wd:Q216497 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q21714344, wd:Q216497, wd:Q146786 .
     FILTER(lang(?indicativeFirstPersonAoristPlural) = "fa") .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeSecondPersonAoristSingularForm .
     ?indicativeSecondPersonAoristSingularForm ontolex:representation ?indicativeSecondPersonAoristSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q682111, wd:Q216497 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q51929049, wd:Q216497, wd:Q110786 .
     FILTER(lang(?indicativeSecondPersonAoristSingular) = "fa") .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeSecondPersonAoristPluralForm .
     ?indicativeSecondPersonAoristPluralForm ontolex:representation ?indicativeSecondPersonAoristPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q682111, wd:Q216497 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q51929049, wd:Q216497, wd:Q146786 .
     FILTER(lang(?indicativeSecondPersonAoristPlural) = "fa") .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeThirdPersonAoristSingularForm .
     ?indicativeThirdPersonAoristSingularForm ontolex:representation ?indicativeThirdPersonAoristSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q682111, wd:Q216497 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q51929074, wd:Q216497, wd:Q110786 .
     FILTER(lang(?indicativeThirdPersonAoristSingular) = "fa") .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativeThirdPersonAoristPluralForm .
     ?indicativeThirdPersonAoristPluralForm ontolex:representation ?indicativeThirdPersonAoristPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q682111, wd:Q216497 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q51929074, wd:Q216497, wd:Q146786 .
     FILTER(lang(?indicativeThirdPersonAoristPlural) = "fa") .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/persian/verbs/query_verbs_3.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/persian/verbs/query_verbs_3.sparql
@@ -22,36 +22,36 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePastFirstPersonSingularForm .
     ?indicativePastFirstPersonSingularForm ontolex:representation ?indicativePastFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q1994301, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q1994301, wd:Q21714344, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePastFirstPersonPluralForm .
     ?indicativePastFirstPersonPluralForm ontolex:representation ?indicativePastFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q1994301, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q1994301, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePastSecondPersonSingularForm .
     ?indicativePastSecondPersonSingularForm ontolex:representation ?indicativePastSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q1994301, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q1994301, wd:Q51929049, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePastSecondPersonPluralForm .
     ?indicativePastSecondPersonPluralForm ontolex:representation ?indicativePastSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q1994301, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q1994301, wd:Q51929049, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePastThirdPersonSingularForm .
     ?indicativePastThirdPersonSingularForm ontolex:representation ?indicativePastThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q1994301, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q1994301, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePastThirdPersonPluralForm .
     ?indicativePastThirdPersonPluralForm ontolex:representation ?indicativePastThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q1994301, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q1994301, wd:Q51929074, wd:Q146786 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/persian/verbs/query_verbs_4.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/persian/verbs/query_verbs_4.sparql
@@ -22,36 +22,36 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presentPerfectFirstPersonSingularForm .
     ?presentPerfectFirstPersonSingularForm ontolex:representation ?presentPerfectFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q625420, wd:Q21714344, wd:Q192613, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q1240211, wd:Q21714344, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presentPerfectFirstPersonPluralForm .
     ?presentPerfectFirstPersonPluralForm ontolex:representation ?presentPerfectFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q625420, wd:Q21714344, wd:Q192613, wd:Q146786 .
+      wikibase:grammaticalFeature wd:Q1240211, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presentPerfectSecondPersonSingularForm .
     ?presentPerfectSecondPersonSingularForm ontolex:representation ?presentPerfectSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q625420, wd:Q51929049, wd:Q192613, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q1240211, wd:Q51929049, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presentPerfectSecondPersonPluralForm .
     ?presentPerfectSecondPersonPluralForm ontolex:representation ?presentPerfectSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q625420, wd:Q51929049, wd:Q192613, wd:Q146786 .
+      wikibase:grammaticalFeature wd:Q1240211, wd:Q51929049, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presentPerfectThirdPersonSingularForm .
     ?presentPerfectThirdPersonSingularForm ontolex:representation ?presentPerfectThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q625420, wd:Q51929074, wd:Q192613, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q1240211, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presentPerfectThirdPersonPluralForm .
     ?presentPerfectThirdPersonPluralForm ontolex:representation ?presentPerfectThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q625420, wd:Q51929074, wd:Q192613, wd:Q146786 .
+      wikibase:grammaticalFeature wd:Q1240211, wd:Q51929074, wd:Q146786 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/persian/verbs/query_verbs_5.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/persian/verbs/query_verbs_5.sparql
@@ -22,36 +22,36 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presentFirstPersonSingularSubjunctiveForm .
     ?presentFirstPersonSingularSubjunctiveForm ontolex:representation ?presentFirstPersonSingularSubjunctive ;
-      wikibase:grammaticalFeature wd:Q473746, wd:Q21714344, wd:Q192613, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q192613, wd:Q21714344, wd:Q110786, wd:Q473746 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presentFirstPersonPluralSubjunctiveForm .
     ?presentFirstPersonPluralSubjunctiveForm ontolex:representation ?presentFirstPersonPluralSubjunctive ;
-      wikibase:grammaticalFeature wd:Q473746, wd:Q21714344, wd:Q192613, wd:Q146786 .
+      wikibase:grammaticalFeature wd:Q192613, wd:Q21714344, wd:Q146786, wd:Q473746 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presentSecondPersonSingularSubjunctiveForm .
     ?presentSecondPersonSingularSubjunctiveForm ontolex:representation ?presentSecondPersonSingularSubjunctive ;
-      wikibase:grammaticalFeature wd:Q473746, wd:Q51929049, wd:Q192613, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q192613, wd:Q51929049, wd:Q110786, wd:Q473746 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presentSecondPersonPluralSubjunctiveForm .
     ?presentSecondPersonPluralSubjunctiveForm ontolex:representation ?presentSecondPersonPluralSubjunctive ;
-      wikibase:grammaticalFeature wd:Q473746, wd:Q51929049, wd:Q192613, wd:Q146786 .
+      wikibase:grammaticalFeature wd:Q192613, wd:Q51929049, wd:Q146786, wd:Q473746 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presentThirdPersonSingularSubjunctiveForm .
     ?presentThirdPersonSingularSubjunctiveForm ontolex:representation ?presentThirdPersonSingularSubjunctive ;
-      wikibase:grammaticalFeature wd:Q473746, wd:Q51929074, wd:Q192613, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q192613, wd:Q51929074, wd:Q110786, wd:Q473746 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presentThirdPersonPluralSubjunctiveForm .
     ?presentThirdPersonPluralSubjunctiveForm ontolex:representation ?presentThirdPersonPluralSubjunctive ;
-      wikibase:grammaticalFeature wd:Q473746, wd:Q51929074, wd:Q192613, wd:Q146786 .
+      wikibase:grammaticalFeature wd:Q192613, wd:Q51929074, wd:Q146786, wd:Q473746 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/polish/verbs/query_verbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/polish/verbs/query_verbs.sparql
@@ -143,36 +143,36 @@ OPTIONAL {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentFirstPersonSingularForm .
     ?indicativePresentFirstPersonSingularForm ontolex:representation ?indicativePresentFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q192613, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q21714344, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentFirstPersonPluralForm .
     ?indicativePresentFirstPersonPluralForm ontolex:representation ?indicativePresentFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q192613, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentSecondPersonSingularForm .
     ?indicativePresentSecondPersonSingularForm ontolex:representation ?indicativePresentSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q192613, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929049, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentSecondPersonPluralForm .
     ?indicativePresentSecondPersonPluralForm ontolex:representation ?indicativePresentSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q192613, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929049, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentThirdPersonSingularForm .
     ?indicativePresentThirdPersonSingularForm ontolex:representation ?indicativePresentThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q192613, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentThirdPersonPluralForm .
     ?indicativePresentThirdPersonPluralForm ontolex:representation ?indicativePresentThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q192613, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929074, wd:Q146786 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/portuguese/verbs/query_verbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/portuguese/verbs/query_verbs.sparql
@@ -53,37 +53,37 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentFirstPersonSingularForm .
     ?indicativePresentFirstPersonSingularForm ontolex:representation ?indicativePresentFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q21714344, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentFirstPersonPluralForm .
     ?indicativePresentFirstPersonPluralForm ontolex:representation ?indicativePresentFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentSecondPersonSingularForm .
     ?indicativePresentSecondPersonSingularForm ontolex:representation ?indicativePresentSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929049, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentSecondPersonPluralForm .
     ?indicativePresentSecondPersonPluralForm ontolex:representation ?indicativePresentSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929049, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentThirdPersonSingularForm .
     ?indicativePresentThirdPersonSingularForm ontolex:representation ?indicativePresentThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentThirdPersonPluralForm .
     ?indicativePresentThirdPersonPluralForm ontolex:representation ?indicativePresentThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929074, wd:Q146786 .
   }
 
   # MARK: Past Imperfect
@@ -91,36 +91,37 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePastImperfectFirstPersonSingularForm .
     ?indicativePastImperfectFirstPersonSingularForm ontolex:representation ?indicativePastImperfectFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q682111, wd:Q12547192 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q12547192, wd:Q21714344, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePastImperfectFirstPersonPluralForm .
     ?indicativePastImperfectFirstPersonPluralForm ontolex:representation ?indicativePastImperfectFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q682111, wd:Q12547192 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q12547192, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePastImperfectSecondPersonSingularForm .
     ?indicativePastImperfectSecondPersonSingularForm ontolex:representation ?indicativePastImperfectSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q682111, wd:Q12547192 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q12547192, wd:Q51929049, wd:Q110786 .
   }
+
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePastImperfectSecondPersonPluralForm .
     ?indicativePastImperfectSecondPersonPluralForm ontolex:representation ?indicativePastImperfectSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q682111, wd:Q12547192 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q12547192, wd:Q51929049, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePastImperfectThirdPersonSingularForm .
     ?indicativePastImperfectThirdPersonSingularForm ontolex:representation ?indicativePastImperfectThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q682111, wd:Q12547192 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q12547192, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePastImperfectThirdPersonPluralForm .
     ?indicativePastImperfectThirdPersonPluralForm ontolex:representation ?indicativePastImperfectThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q682111, wd:Q12547192 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q12547192, wd:Q51929074, wd:Q146786 .
   }
 
   # MARK: Past Perfect
@@ -128,37 +129,37 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePastPerfectFirstPersonSingularForm .
     ?indicativePastPerfectFirstPersonSingularForm ontolex:representation ?indicativePastPerfectFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q682111, wd:Q64005357 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q64005357, wd:Q21714344, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePastPerfectFirstPersonPluralForm .
     ?indicativePastPerfectFirstPersonPluralForm ontolex:representation ?indicativePastPerfectFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q682111, wd:Q64005357 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q64005357, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePastPerfectSecondPersonSingularForm .
     ?indicativePastPerfectSecondPersonSingularForm ontolex:representation ?indicativePastPerfectSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q682111, wd:Q64005357 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q64005357, wd:Q51929049, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePastPerfectSecondPersonPluralForm .
     ?indicativePastPerfectSecondPersonPluralForm ontolex:representation ?indicativePastPerfectSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q682111, wd:Q64005357 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q64005357, wd:Q51929049, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePastPerfectThirdPersonSingularForm .
     ?indicativePastPerfectThirdPersonSingularForm ontolex:representation ?indicativePastPerfectThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q682111, wd:Q64005357 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q64005357, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePastPerfectThirdPersonPluralForm .
     ?indicativePastPerfectThirdPersonPluralForm ontolex:representation ?indicativePastPerfectThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q682111, wd:Q64005357 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q64005357, wd:Q51929074, wd:Q146786 .
   }
 
   # MARK: Pluperfect
@@ -166,36 +167,35 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePluperfectFirstPersonSingularForm .
     ?indicativePluperfectFirstPersonSingularForm ontolex:representation ?indicativePluperfectFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q623742, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q623742, wd:Q21714344, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePluperfectFirstPersonPluralForm .
     ?indicativePluperfectFirstPersonPluralForm ontolex:representation ?indicativePluperfectFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q623742, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q623742, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePluperfectSecondPersonSingularForm .
     ?indicativePluperfectSecondPersonSingularForm ontolex:representation ?indicativePluperfectSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q623742, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q623742, wd:Q51929049, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePluperfectSecondPersonPluralForm .
     ?indicativePluperfectSecondPersonPluralForm ontolex:representation ?indicativePluperfectSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q623742, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q623742, wd:Q51929049, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePluperfectThirdPersonSingularForm .
     ?indicativePluperfectThirdPersonSingularForm ontolex:representation ?indicativePluperfectThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q623742, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q623742, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePluperfectThirdPersonPluralForm .
     ?indicativePluperfectThirdPersonPluralForm ontolex:representation ?indicativePluperfectThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q623742, wd:Q682111 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q623742, wd:Q51929074, wd:Q146786 .
   }
-}

--- a/src/scribe_data/wikidata/language_data_extraction/russian/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/russian/adjectives/query_adjectives.sparql
@@ -84,7 +84,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pluralShortForm .
     ?pluralShortForm ontolex:representation ?pluralShort ;
-      wikibase:grammaticalFeature wd:Q4239848, wd:Q146786 .
+      wikibase:grammaticalFeature wd:Q146786, wd:Q4239848 .
   }
 
   # MARK: Nominative Singular
@@ -92,19 +92,19 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeFeminineSingularForm .
     ?nominativeFeminineSingularForm ontolex:representation ?nominativeFeminineSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q131105, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q1775415, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeMasculineSingularForm .
     ?nominativeMasculineSingularForm ontolex:representation ?nominativeMasculineSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q131105, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q499327, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeNeuterSingularForm .
     ?nominativeNeuterSingularForm ontolex:representation ?nominativeNeuterSingular ;
-      wikibase:grammaticalFeature wd:Q1775461, wd:Q131105, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q1775461, wd:Q110786 .
   }
 
   # MARK: Genitive Singular
@@ -112,19 +112,19 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveFeminineSingularForm .
     ?genitiveFeminineSingularForm ontolex:representation ?genitiveFeminineSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q146233, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q146233, wd:Q1775415, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveMasculineSingularForm .
     ?genitiveMasculineSingularForm ontolex:representation ?genitiveMasculineSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q146233, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q146233, wd:Q499327, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveNeuterSingularForm .
     ?genitiveNeuterSingularForm ontolex:representation ?genitiveNeuterSingular ;
-      wikibase:grammaticalFeature wd:Q1775461, wd:Q146233, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q146233, wd:Q1775461, wd:Q110786 .
   }
 
   # MARK: Dative Singular
@@ -132,19 +132,19 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?dativeFeminineSingularForm .
     ?dativeFeminineSingularForm ontolex:representation ?dativeFeminineSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q145599, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q145599, wd:Q1775415, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?dativeMasculineSingularForm .
     ?dativeMasculineSingularForm ontolex:representation ?dativeMasculineSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q145599, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q145599, wd:Q499327, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?dativeNeuterSingularForm .
     ?dativeNeuterSingularForm ontolex:representation ?dativeNeuterSingular ;
-      wikibase:grammaticalFeature wd:Q1775461, wd:Q145599, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q145599, wd:Q1775461, wd:Q110786 .
   }
 
   # MARK: Accusative Singular
@@ -152,43 +152,45 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeInanimateSingularForm .
     ?accusativeInanimateSingularForm ontolex:representation ?accusativeInanimateSingular ;
-      wikibase:grammaticalFeature wd:Q51927539, wd:Q146078, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q146078, wd:Q51927539, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeInanimatePluralForm .
     ?accusativeInanimatePluralForm ontolex:representation ?accusativeInanimatePlural ;
-      wikibase:grammaticalFeature wd:Q51927539, wd:Q146078, wd:Q146786 .
+      wikibase:grammaticalFeature wd:Q146078, wd:Q51927539, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeAnimatePluralForm .
     ?accusativeAnimatePluralForm ontolex:representation ?accusativeAnimatePlural ;
-      wikibase:grammaticalFeature wd:Q51927507, wd:Q146078, wd:Q146786 .
+      wikibase:grammaticalFeature wd:Q146078, wd:Q51927507, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeMasculineAnimateSingularForm .
     ?accusativeMasculineAnimateSingularForm ontolex:representation ?accusativeMasculineAnimateSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q51927507, wd:Q146078, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q146078, wd:Q54020116, wd:Q110786 .
   }
+
+  # MARK: Instrumental Singular
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?instrumentalFeminineSingularForm .
     ?instrumentalFeminineSingularForm ontolex:representation ?instrumentalFeminineSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q192997, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q192997, wd:Q1775415, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?instrumentalMasculineSingularForm .
     ?instrumentalMasculineSingularForm ontolex:representation ?instrumentalMasculineSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q192997, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q192997, wd:Q499327, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?instrumentalNeuterSingularForm .
     ?instrumentalNeuterSingularForm ontolex:representation ?instrumentalNeuterSingular ;
-      wikibase:grammaticalFeature wd:Q1775461, wd:Q192997, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q192997, wd:Q1775461, wd:Q110786 .
   }
 
   # MARK: Prepositional Singular
@@ -196,19 +198,19 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?prepositionalFeminineSingularForm .
     ?prepositionalFeminineSingularForm ontolex:representation ?prepositionalFeminineSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q2114906, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q2114906, wd:Q1775415, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?prepositionalMasculineSingularForm .
     ?prepositionalMasculineSingularForm ontolex:representation ?prepositionalMasculineSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q2114906, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q2114906, wd:Q499327, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?prepositionalNeuterSingularForm .
     ?prepositionalNeuterSingularForm ontolex:representation ?prepositionalNeuterSingular ;
-      wikibase:grammaticalFeature wd:Q1775461, wd:Q2114906, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q2114906, wd:Q1775461, wd:Q110786 .
   }
 
   # MARK: Short Singular
@@ -216,20 +218,21 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?feminineSingularShortForm .
     ?feminineSingularShortForm ontolex:representation ?feminineSingularShort ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q4239848, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q110786, wd:Q4239848 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineSingularShortForm .
     ?masculineSingularShortForm ontolex:representation ?masculineSingularShort ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q4239848, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q110786, wd:Q4239848 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?neuterSingularShortForm .
     ?neuterSingularShortForm ontolex:representation ?neuterSingularShort ;
-      wikibase:grammaticalFeature wd:Q1775461, wd:Q4239848, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q1775461, wd:Q110786, wd:Q4239848 .
   }
+
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeFeminineAnimateSingularForm .
     ?accusativeFeminineAnimateSingularForm ontolex:representation ?accusativeFeminineAnimateSingular ;

--- a/src/scribe_data/wikidata/language_data_extraction/russian/verbs/query_verbs.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/russian/verbs/query_verbs.sparql
@@ -32,7 +32,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?feminineIndicativePastForm .
     ?feminineIndicativePastForm ontolex:representation ?feminineIndicativePast ;
-      wikibase:grammaticalFeature wd:Q682111, wd:Q1994301, wd:Q1775415 .
+      wikibase:grammaticalFeature wd:Q1775415, wd:Q682111, wd:Q1994301 .
   }
 
   # MARK: Past Masculine
@@ -40,7 +40,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?masculineIndicativePastForm .
     ?masculineIndicativePastForm ontolex:representation ?masculineIndicativePast ;
-      wikibase:grammaticalFeature wd:Q682111, wd:Q1994301, wd:Q499327 .
+      wikibase:grammaticalFeature wd:Q499327, wd:Q682111, wd:Q1994301 .
   }
 
   # MARK: Past Neutral
@@ -48,7 +48,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?neuterIndicativePastForm .
     ?neuterIndicativePastForm ontolex:representation ?neuterIndicativePast ;
-      wikibase:grammaticalFeature wd:Q682111, wd:Q1994301, wd:Q1775461 .
+      wikibase:grammaticalFeature wd:Q1775461, wd:Q682111, wd:Q1994301 .
   }
 
   # MARK: Past Plural
@@ -56,7 +56,7 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePastPluralForm .
     ?indicativePastPluralForm ontolex:representation ?indicativePastPlural ;
-      wikibase:grammaticalFeature wd:Q146786, wd:Q682111, wd:Q1994301 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q1994301, wd:Q146786 .
   }
 
   # MARK: Indicative Present
@@ -64,36 +64,36 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentFirstPersonSingularForm .
     ?indicativePresentFirstPersonSingularForm ontolex:representation ?indicativePresentFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q21714344, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentFirstPersonPluralForm .
     ?indicativePresentFirstPersonPluralForm ontolex:representation ?indicativePresentFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentSecondPersonSingularForm .
     ?indicativePresentSecondPersonSingularForm ontolex:representation ?indicativePresentSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929049, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentSecondPersonPluralForm .
     ?indicativePresentSecondPersonPluralForm ontolex:representation ?indicativePresentSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929049, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentThirdPersonSingularForm .
     ?indicativePresentThirdPersonSingularForm ontolex:representation ?indicativePresentThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentThirdPersonPluralForm .
     ?indicativePresentThirdPersonPluralForm ontolex:representation ?indicativePresentThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929074, wd:Q146786 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/slovak/adjectives/query_adjectives_1.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/slovak/adjectives/query_adjectives_1.sparql
@@ -21,30 +21,30 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeFeminineSingularPositiveForm .
     ?nominativeFeminineSingularPositiveForm ontolex:representation ?nominativeFeminineSingularPositive ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q131105, wd:Q110786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q1775415, wd:Q110786, wd:Q3482678 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeMasculineSingularPositiveForm .
     ?nominativeMasculineSingularPositiveForm ontolex:representation ?nominativeMasculineSingularPositive ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q131105, wd:Q110786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q499327, wd:Q110786, wd:Q3482678 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeMasculinePersonalPluralPositiveForm .
     ?nominativeMasculinePersonalPluralPositiveForm ontolex:representation ?nominativeMasculinePersonalPluralPositive ;
-      wikibase:grammaticalFeature wd:Q27918551, wd:Q131105, wd:Q146786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q27918551, wd:Q146786, wd:Q3482678 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeNotMasculinePersonalPluralPositiveForm .
     ?nominativeNotMasculinePersonalPluralPositiveForm ontolex:representation ?nominativeNotMasculinePersonalPluralPositive ;
-      wikibase:grammaticalFeature wd:Q54152717, wd:Q131105, wd:Q146786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q54152717, wd:Q146786, wd:Q3482678 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeNeuterSingularPositiveForm .
     ?nominativeNeuterSingularPositiveForm ontolex:representation ?nominativeNeuterSingularPositive ;
-      wikibase:grammaticalFeature wd:Q1775461, wd:Q131105, wd:Q110786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q1775461, wd:Q110786, wd:Q3482678 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/slovak/adjectives/query_adjectives_2.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/slovak/adjectives/query_adjectives_2.sparql
@@ -26,18 +26,18 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveFeminineSingularPositiveForm .
     ?genitiveFeminineSingularPositiveForm ontolex:representation ?genitiveFeminineSingularPositive ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q146233, wd:Q110786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q146233, wd:Q1775415, wd:Q110786, wd:Q3482678 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveMasculineSingularPositiveForm .
     ?genitiveMasculineSingularPositiveForm ontolex:representation ?genitiveMasculineSingularPositive ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q146233, wd:Q110786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q146233, wd:Q499327, wd:Q110786, wd:Q3482678 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveNeuterSingularPositiveForm .
     ?genitiveNeuterSingularPositiveForm ontolex:representation ?genitiveNeuterSingularPositive ;
-      wikibase:grammaticalFeature wd:Q1775461, wd:Q146233, wd:Q110786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q146233, wd:Q1775461, wd:Q110786, wd:Q3482678 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/slovak/adjectives/query_adjectives_3.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/slovak/adjectives/query_adjectives_3.sparql
@@ -26,18 +26,18 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?dativeFeminineSingularPositiveForm .
     ?dativeFeminineSingularPositiveForm ontolex:representation ?dativeFeminineSingularPositive ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q145599, wd:Q110786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q145599, wd:Q1775415, wd:Q110786, wd:Q3482678 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?dativeMasculineSingularPositiveForm .
     ?dativeMasculineSingularPositiveForm ontolex:representation ?dativeMasculineSingularPositive ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q145599, wd:Q110786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q145599, wd:Q499327, wd:Q110786, wd:Q3482678 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?dativeNeuterSingularPositiveForm .
     ?dativeNeuterSingularPositiveForm ontolex:representation ?dativeNeuterSingularPositive ;
-      wikibase:grammaticalFeature wd:Q1775461, wd:Q145599, wd:Q110786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q145599, wd:Q1775461, wd:Q110786, wd:Q3482678 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/slovak/adjectives/query_adjectives_4.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/slovak/adjectives/query_adjectives_4.sparql
@@ -22,36 +22,36 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeFeminineSingularPositiveForm .
     ?accusativeFeminineSingularPositiveForm ontolex:representation ?accusativeFeminineSingularPositive ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q146078, wd:Q110786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q146078, wd:Q1775415, wd:Q110786, wd:Q3482678 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeMasculineInanimateSingularPositiveForm .
     ?accusativeMasculineInanimateSingularPositiveForm ontolex:representation ?accusativeMasculineInanimateSingularPositive ;
-      wikibase:grammaticalFeature wd:Q52943434, wd:Q146078, wd:Q110786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q146078, wd:Q52943434, wd:Q110786, wd:Q3482678 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeMasculineAnimateSingularPositiveForm .
     ?accusativeMasculineAnimateSingularPositiveForm ontolex:representation ?accusativeMasculineAnimateSingularPositive ;
-      wikibase:grammaticalFeature wd:Q54020116, wd:Q146078, wd:Q110786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q146078, wd:Q54020116, wd:Q110786, wd:Q3482678 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeMasculinePersonalPluralPositiveForm .
     ?accusativeMasculinePersonalPluralPositiveForm ontolex:representation ?accusativeMasculinePersonalPluralPositive ;
-      wikibase:grammaticalFeature wd:Q27918551, wd:Q146078, wd:Q146786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q146078, wd:Q27918551, wd:Q146786, wd:Q3482678 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeNotMasculinePersonalPluralPositiveForm .
     ?accusativeNotMasculinePersonalPluralPositiveForm ontolex:representation ?accusativeNotMasculinePersonalPluralPositive ;
-      wikibase:grammaticalFeature wd:Q54152717, wd:Q146078, wd:Q146786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q146078, wd:Q54152717, wd:Q146786, wd:Q3482678 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?accusativeNeuterSingularPositiveForm .
     ?accusativeNeuterSingularPositiveForm ontolex:representation ?accusativeNeuterSingularPositive ;
-      wikibase:grammaticalFeature wd:Q1775461, wd:Q146078, wd:Q110786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q146078, wd:Q1775461, wd:Q110786, wd:Q3482678 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/slovak/adjectives/query_adjectives_5.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/slovak/adjectives/query_adjectives_5.sparql
@@ -26,18 +26,18 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?locativeFeminineSingularPositiveForm .
     ?locativeFeminineSingularPositiveForm ontolex:representation ?locativeFeminineSingularPositive ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q202142, wd:Q110786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q202142, wd:Q1775415, wd:Q110786, wd:Q3482678 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?locativeMasculineSingularPositiveForm .
     ?locativeMasculineSingularPositiveForm ontolex:representation ?locativeMasculineSingularPositive ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q202142, wd:Q110786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q202142, wd:Q499327, wd:Q110786, wd:Q3482678 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?locativeNeuterSingularPositiveForm .
     ?locativeNeuterSingularPositiveForm ontolex:representation ?locativeNeuterSingularPositive ;
-      wikibase:grammaticalFeature wd:Q1775461, wd:Q202142, wd:Q110786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q202142, wd:Q1775461, wd:Q110786, wd:Q3482678 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/slovak/adjectives/query_adjectives_6.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/slovak/adjectives/query_adjectives_6.sparql
@@ -26,18 +26,18 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?instrumentalFeminineSingularPositiveForm .
     ?instrumentalFeminineSingularPositiveForm ontolex:representation ?instrumentalFeminineSingularPositive ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q192997, wd:Q110786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q192997, wd:Q1775415, wd:Q110786, wd:Q3482678 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?instrumentalMasculineSingularPositiveForm .
     ?instrumentalMasculineSingularPositiveForm ontolex:representation ?instrumentalMasculineSingularPositive ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q192997, wd:Q110786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q192997, wd:Q499327, wd:Q110786, wd:Q3482678 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?instrumentalNeuterSingularPositiveForm .
     ?instrumentalNeuterSingularPositiveForm ontolex:representation ?instrumentalNeuterSingularPositive ;
-      wikibase:grammaticalFeature wd:Q1775461, wd:Q192997, wd:Q110786, wd:Q3482678 .
+      wikibase:grammaticalFeature wd:Q192997, wd:Q1775461, wd:Q110786, wd:Q3482678 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/spanish/verbs/query_verbs_1.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/spanish/verbs/query_verbs_1.sparql
@@ -22,36 +22,36 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentFirstPersonSingularForm .
     ?indicativePresentFirstPersonSingularForm ontolex:representation ?indicativePresentFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q21714344, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentFirstPersonPluralForm .
     ?indicativePresentFirstPersonPluralForm ontolex:representation ?indicativePresentFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentSecondPersonSingularForm .
     ?indicativePresentSecondPersonSingularForm ontolex:representation ?indicativePresentSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929049, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentSecondPersonPluralForm .
     ?indicativePresentSecondPersonPluralForm ontolex:representation ?indicativePresentSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929049, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentThirdPersonSingularForm .
     ?indicativePresentThirdPersonSingularForm ontolex:representation ?indicativePresentThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?indicativePresentThirdPersonPluralForm .
     ?indicativePresentThirdPersonPluralForm ontolex:representation ?indicativePresentThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q682111, wd:Q192613 .
+      wikibase:grammaticalFeature wd:Q682111, wd:Q192613, wd:Q51929074, wd:Q146786 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/spanish/verbs/query_verbs_2.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/spanish/verbs/query_verbs_2.sparql
@@ -22,35 +22,35 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?preteriteFirstPersonSingularForm .
     ?preteriteFirstPersonSingularForm ontolex:representation ?preteriteFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q442485 .
+      wikibase:grammaticalFeature wd:Q442485, wd:Q21714344, wd:Q110786 .
   }
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?preteriteFirstPersonPluralForm .
     ?preteriteFirstPersonPluralForm ontolex:representation ?preteriteFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q442485 .
+      wikibase:grammaticalFeature wd:Q442485, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?preteriteSecondPersonSingularForm .
     ?preteriteSecondPersonSingularForm ontolex:representation ?preteriteSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q442485 .
+      wikibase:grammaticalFeature wd:Q442485, wd:Q51929049, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?preteriteSecondPersonPluralForm .
     ?preteriteSecondPersonPluralForm ontolex:representation ?preteriteSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q442485 .
+      wikibase:grammaticalFeature wd:Q442485, wd:Q51929049, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?preteriteThirdPersonSingularForm .
     ?preteriteThirdPersonSingularForm ontolex:representation ?preteriteThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q442485 .
+      wikibase:grammaticalFeature wd:Q442485, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?preteriteThirdPersonPluralForm .
     ?preteriteThirdPersonPluralForm ontolex:representation ?preteriteThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q442485 .
+      wikibase:grammaticalFeature wd:Q442485, wd:Q51929074, wd:Q146786 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/spanish/verbs/query_verbs_3.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/spanish/verbs/query_verbs_3.sparql
@@ -22,35 +22,35 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pastImperfectFirstPersonSingularForm .
     ?pastImperfectFirstPersonSingularForm ontolex:representation ?pastImperfectFirstPersonSingular ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q110786, wd:Q12547192 .
+      wikibase:grammaticalFeature wd:Q12547192, wd:Q21714344, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pastImperfectFirstPersonPluralForm .
     ?pastImperfectFirstPersonPluralForm ontolex:representation ?pastImperfectFirstPersonPlural ;
-      wikibase:grammaticalFeature wd:Q21714344, wd:Q146786, wd:Q12547192 .
+      wikibase:grammaticalFeature wd:Q12547192, wd:Q21714344, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pastImperfectSecondPersonSingularForm .
     ?pastImperfectSecondPersonSingularForm ontolex:representation ?pastImperfectSecondPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q110786, wd:Q12547192 .
+      wikibase:grammaticalFeature wd:Q12547192, wd:Q51929049, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pastImperfectSecondPersonPluralForm .
     ?pastImperfectSecondPersonPluralForm ontolex:representation ?pastImperfectSecondPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929049, wd:Q146786, wd:Q12547192 .
+      wikibase:grammaticalFeature wd:Q12547192, wd:Q51929049, wd:Q146786 .
   }
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pastImperfectThirdPersonSingularForm .
     ?pastImperfectThirdPersonSingularForm ontolex:representation ?pastImperfectThirdPersonSingular ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q110786, wd:Q12547192 .
+      wikibase:grammaticalFeature wd:Q12547192, wd:Q51929074, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pastImperfectThirdPersonPluralForm .
     ?pastImperfectThirdPersonPluralForm ontolex:representation ?pastImperfectThirdPersonPlural ;
-      wikibase:grammaticalFeature wd:Q51929074, wd:Q146786, wd:Q12547192 .
+      wikibase:grammaticalFeature wd:Q12547192, wd:Q51929074, wd:Q146786 .
   }
 }

--- a/src/scribe_data/wikidata/language_data_extraction/swedish/nouns/query_nouns.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/swedish/nouns/query_nouns.sparql
@@ -25,25 +25,25 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeIndefiniteSingularForm .
     ?nominativeIndefiniteSingularForm ontolex:representation ?nominativeIndefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q53997857, wd:Q131105, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q53997857, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeIndefinitePluralForm .
     ?nominativeIndefinitePluralForm ontolex:representation ?nominativeIndefinitePlural ;
-      wikibase:grammaticalFeature wd:Q53997857, wd:Q131105, wd:Q146786 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q53997857, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeDefiniteSingularForm .
     ?nominativeDefiniteSingularForm ontolex:representation ?nominativeDefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q53997851, wd:Q131105, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q53997851, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeDefinitePluralForm .
     ?nominativeDefinitePluralForm ontolex:representation ?nominativeDefinitePlural ;
-      wikibase:grammaticalFeature wd:Q53997851, wd:Q131105, wd:Q146786 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q53997851, wd:Q146786 .
   }
 
   # MARK: Genitive
@@ -51,25 +51,25 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveIndefiniteSingularForm .
     ?genitiveIndefiniteSingularForm ontolex:representation ?genitiveIndefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q53997857, wd:Q146233, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q146233, wd:Q53997857, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveIndefinitePluralForm .
     ?genitiveIndefinitePluralForm ontolex:representation ?genitiveIndefinitePlural ;
-      wikibase:grammaticalFeature wd:Q53997857, wd:Q146233, wd:Q146786 .
+      wikibase:grammaticalFeature wd:Q146233, wd:Q53997857, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveDefiniteSingularForm .
     ?genitiveDefiniteSingularForm ontolex:representation ?genitiveDefiniteSingular ;
-      wikibase:grammaticalFeature wd:Q53997851, wd:Q146233, wd:Q110786 .
+      wikibase:grammaticalFeature wd:Q146233, wd:Q53997851, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?genitiveDefinitePluralForm .
     ?genitiveDefinitePluralForm ontolex:representation ?genitiveDefinitePlural ;
-      wikibase:grammaticalFeature wd:Q53997851, wd:Q146233, wd:Q146786 .
+      wikibase:grammaticalFeature wd:Q146233, wd:Q53997851, wd:Q146786 .
   }
 
   # MARK: Gender(s)

--- a/src/scribe_data/wikidata/language_data_extraction/ukrainian/adjectives/query_adjectives.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/ukrainian/adjectives/query_adjectives.sparql
@@ -40,24 +40,24 @@ WHERE {
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativePluralForm .
     ?nominativePluralForm ontolex:representation ?nominativePlural ;
-      wikibase:grammaticalFeature wd:Q146786, wd:Q131105 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q146786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeFeminineSingularForm .
     ?nominativeFeminineSingularForm ontolex:representation ?nominativeFeminineSingular ;
-      wikibase:grammaticalFeature wd:Q1775415, wd:Q110786, wd:Q131105 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q1775415, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeMasculineSingularForm .
     ?nominativeMasculineSingularForm ontolex:representation ?nominativeMasculineSingular ;
-      wikibase:grammaticalFeature wd:Q499327, wd:Q110786, wd:Q131105 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q499327, wd:Q110786 .
   }
 
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?nominativeNeuterSingularForm .
     ?nominativeNeuterSingularForm ontolex:representation ?nominativeNeuterSingular ;
-      wikibase:grammaticalFeature wd:Q1775461, wd:Q110786, wd:Q131105 .
+      wikibase:grammaticalFeature wd:Q131105, wd:Q1775461, wd:Q110786 .
   }
 }


### PR DESCRIPTION
- Introduced check_optional_qid_order function to validate the order of QIDs in optional statements within SPARQL queries.
- Extracted label decomposition logic into the decompose_label_features function, which is now used in both functions.
- Updated check_query_forms to include validation for the correct order of QIDs in OPTIONAL clauses.

<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description


This PR introduces a new function `check_optional_qid_order` to validate the order of QIDs in optional statements within SPARQL queries. Additionally, the label decomposition logic has been refactored into the `decompose_label_features` function, which is now used in both `check_forms_order` and `check_optional_qid_order` for better readability and consistency. The `check_query_forms` function has been updated to include validation for the correct order of QIDs in OPTIONAL clauses.

Note: The queries are still in progress and will be finalized once the function is approved.

### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- Last PR to close #450 