### PR TITLE
Fix version comparison bug in get_version_message() due to prefix inconsistencies

### DIFF
--- a/src/scribe_data/cli/version.py
+++ b/src/scribe_data/cli/version.py
@@ -44,19 +44,22 @@ def get_latest_version():
 
 
 def get_version_message():
-    local_version = f"Scribe-Data v{get_local_version()}"
+    local_version = get_local_version()
     latest_version = get_latest_version()
 
-    if (
-        local_version == "Unknown (Not installed via pip)"
-        or latest_version == "Unknown (Unable to fetch version)"
-    ):
-        return f"{local_version}"
+    if local_version == "Unknown (Not installed via pip)":
+        return f"Scribe-Data {local_version}"
+    elif latest_version == "Unknown (Unable to fetch version)":
+        return f"Scribe-Data {latest_version}"
 
-    if local_version == latest_version:
-        return f"{local_version}"
+    local_version_clean = local_version.strip()
+    latest_version_clean = latest_version.replace("Scribe-Data", "").strip()
 
-    update_message = f"{local_version} (Upgrade available: {latest_version})\n"
-    update_message += "To update: pip scribe-data --upgrade"
+    if local_version_clean == latest_version_clean:
+        return f"Scribe-Data v{local_version_clean}"
 
+    update_message = (
+        f"Scribe-Data v{local_version_clean} (Upgrade available: Scribe-Data v{latest_version_clean})\n"
+        "To update: pip install --upgrade scribe-data"
+    )
     return update_message

--- a/src/scribe_data/cli/version.py
+++ b/src/scribe_data/cli/version.py
@@ -58,8 +58,4 @@ def get_version_message():
     if local_version_clean == latest_version_clean:
         return f"Scribe-Data v{local_version_clean}"
 
-    update_message = (
-        f"Scribe-Data v{local_version_clean} (Upgrade available: Scribe-Data v{latest_version_clean})\n"
-        "To update: pip install --upgrade scribe-data"
-    )
-    return update_message
+    return f"Scribe-Data v{local_version_clean} (Upgrade available: Scribe-Data v{latest_version_clean})\nTo update: pip install --upgrade scribe-data"

--- a/tests/cli/test_version.py
+++ b/tests/cli/test_version.py
@@ -53,9 +53,9 @@ class TestVersionFunctions(unittest.TestCase):
     def test_get_latest_version_failure(self, mock_get):
         self.assertEqual(get_latest_version(), "Unknown (Unable to fetch version)")
 
-    @patch("scribe_data.cli.version.get_local_version", return_value="4.1.0")
+    @patch("scribe_data.cli.version.get_local_version", return_value="X.Y.Z")
     @patch(
-        "scribe_data.cli.version.get_latest_version", return_value="Scribe-Data 4.1.0"
+        "scribe_data.cli.version.get_latest_version", return_value="Scribe-Data X.Y.Z"
     )
     def test_get_version_message_up_to_date(
         self, mock_latest_version, mock_local_version
@@ -63,19 +63,19 @@ class TestVersionFunctions(unittest.TestCase):
         """
         Tests the scenario where the local version is up to date with the latest version.
         """
-        expected_message = "Scribe-Data v4.1.0"
+        expected_message = "Scribe-Data vX.Y.Z"
         self.assertEqual(get_version_message(), expected_message)
 
-    @patch("scribe_data.cli.version.get_local_version", return_value="4.0.0")
+    @patch("scribe_data.cli.version.get_local_version", return_value="X.Y.Y")
     @patch(
-        "scribe_data.cli.version.get_latest_version", return_value="Scribe-Data 4.1.0"
+        "scribe_data.cli.version.get_latest_version", return_value="Scribe-Data X.Y.Z"
     )
     def test_upgrade_available(self, mock_latest_version, mock_local_version):
         """
         Test case where a newer version is available.
         """
         expected_message = (
-            "Scribe-Data v4.0.0 (Upgrade available: Scribe-Data v4.1.0)\n"
+            "Scribe-Data vX.Y.Y (Upgrade available: Scribe-Data vX.Y.Z)\n"
             "To update: pip install --upgrade scribe-data"
         )
         self.assertEqual(get_version_message(), expected_message)
@@ -85,7 +85,7 @@ class TestVersionFunctions(unittest.TestCase):
         return_value="Unknown (Not installed via pip)",
     )
     @patch(
-        "scribe_data.cli.version.get_latest_version", return_value="Scribe-Data 4.1.0"
+        "scribe_data.cli.version.get_latest_version", return_value="Scribe-Data X.Y.Z"
     )
     def test_local_version_unknown(self, mock_latest_version, mock_local_version):
         """
@@ -94,7 +94,7 @@ class TestVersionFunctions(unittest.TestCase):
         expected_message = "Scribe-Data Unknown (Not installed via pip)"
         self.assertEqual(get_version_message(), expected_message)
 
-    @patch("scribe_data.cli.version.get_local_version", return_value="4.1.0")
+    @patch("scribe_data.cli.version.get_local_version", return_value="X.Y.Z")
     @patch(
         "scribe_data.cli.version.get_latest_version",
         return_value="Unknown (Unable to fetch version)",

--- a/tests/cli/test_version.py
+++ b/tests/cli/test_version.py
@@ -53,9 +53,9 @@ class TestVersionFunctions(unittest.TestCase):
     def test_get_latest_version_failure(self, mock_get):
         self.assertEqual(get_latest_version(), "Unknown (Unable to fetch version)")
 
-    @patch("scribe_data.cli.version.get_local_version", return_value="1.0.0")
+    @patch("scribe_data.cli.version.get_local_version", return_value="4.1.0")
     @patch(
-        "scribe_data.cli.version.get_latest_version", return_value="Scribe-Data v1.0.0"
+        "scribe_data.cli.version.get_latest_version", return_value="Scribe-Data 4.1.0"
     )
     def test_get_version_message_up_to_date(
         self, mock_latest_version, mock_local_version
@@ -63,18 +63,45 @@ class TestVersionFunctions(unittest.TestCase):
         """
         Tests the scenario where the local version is up to date with the latest version.
         """
-        expected_message = "Scribe-Data v1.0.0"
+        expected_message = "Scribe-Data v4.1.0"
         self.assertEqual(get_version_message(), expected_message)
 
-    @patch("scribe_data.cli.version.get_local_version", return_value="1.0.0")
+    @patch("scribe_data.cli.version.get_local_version", return_value="4.0.0")
     @patch(
-        "scribe_data.cli.version.get_latest_version", return_value="Scribe-Data v1.0.1"
+        "scribe_data.cli.version.get_latest_version", return_value="Scribe-Data 4.1.0"
     )
-    def test_get_version_message_update_available(
-        self, mock_latest_version, mock_local_version
-    ):
+    def test_upgrade_available(self, mock_latest_version, mock_local_version):
         """
-        Tests the scenario where a newer version is available, suggesting an update.
+        Test case where a newer version is available.
         """
-        expected_message = "Scribe-Data v1.0.0 (Upgrade available: Scribe-Data v1.0.1)\nTo update: pip scribe-data --upgrade"
+        expected_message = (
+            "Scribe-Data v4.0.0 (Upgrade available: Scribe-Data v4.1.0)\n"
+            "To update: pip install --upgrade scribe-data"
+        )
+        self.assertEqual(get_version_message(), expected_message)
+
+    @patch(
+        "scribe_data.cli.version.get_local_version",
+        return_value="Unknown (Not installed via pip)",
+    )
+    @patch(
+        "scribe_data.cli.version.get_latest_version", return_value="Scribe-Data 4.1.0"
+    )
+    def test_local_version_unknown(self, mock_latest_version, mock_local_version):
+        """
+        Test case where the local version is unknown.
+        """
+        expected_message = "Scribe-Data Unknown (Not installed via pip)"
+        self.assertEqual(get_version_message(), expected_message)
+
+    @patch("scribe_data.cli.version.get_local_version", return_value="4.1.0")
+    @patch(
+        "scribe_data.cli.version.get_latest_version",
+        return_value="Unknown (Unable to fetch version)",
+    )
+    def test_latest_version_unknown(self, mock_latest_version, mock_local_version):
+        """
+        Test case where the latest version cannot be fetched.
+        """
+        expected_message = "Scribe-Data Unknown (Unable to fetch version)"
         self.assertEqual(get_version_message(), expected_message)


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

When you run the command scribe-data -v, even if you have the latest version, it incorrectly reports that an update is available. This issue arises due to mismatched values fetched from get_local_version and get_latest_version. The fix involves stripping unnecessary values and comparing only the relevant ones. Additionally, the command to update scribe-data was incorrect and has been corrected.

For testing, I added cases where the local and latest versions are either unknown or different.

### Related issue

- #534 
