### PR TITLE
Added pipe-separated values along with lexeme dump  

### DIFF
--- a/src/scribe_data/wikidata/format_data.py
+++ b/src/scribe_data/wikidata/format_data.py
@@ -6,6 +6,8 @@ Formats the data queried from Wikidata using query_verbs.sparql.
 import argparse
 import collections
 
+from rich import print as rprint
+
 from scribe_data.utils import (
     export_formatted_data,
     load_queried_data,
@@ -77,10 +79,10 @@ def format_data(
                     ):
                         # Merge field values into a comma-separated string using a set for uniqueness.
                         existing_values = set(
-                            data_formatted[lexeme_id][field].split("| ")
+                            data_formatted[lexeme_id][field].split(" | ")
                         )
                         existing_values.add(value)
-                        data_formatted[lexeme_id][field] = "| ".join(
+                        data_formatted[lexeme_id][field] = " | ".join(
                             sorted(existing_values)
                         )
 
@@ -93,7 +95,7 @@ def format_data(
     # Check if any values contain pipe separator before exporting.
     for lexeme_data in data_formatted.values():
         for value in lexeme_data.values():
-            if isinstance(value, str) and "| " in value:
+            if isinstance(value, str) and " | " in value:
                 has_multiple_forms = True
                 break
         if has_multiple_forms:
@@ -107,8 +109,8 @@ def format_data(
     )
 
     if has_multiple_forms:
-        print(
-            "Note: Multiple versions of forms have been returned. These have been combined with '|' in the resulting data fields."
+        rprint(
+            "[bold yellow]Note: Multiple versions of forms have been returned. These have been combined with '|' in the resulting data fields.[/bold yellow]"
         )
 
     remove_queried_data(dir_path=dir_path, language=language, data_type=data_type)

--- a/src/scribe_data/wikidata/format_data.py
+++ b/src/scribe_data/wikidata/format_data.py
@@ -48,6 +48,7 @@ def format_data(
     )
 
     data_formatted = {}
+    has_multiple_forms = False
 
     for data_vals in data_list:
         lexeme_id = data_vals["lexemeID"]
@@ -75,10 +76,10 @@ def format_data(
                     ):
                         # Merge field values into a comma-separated string using a set for uniqueness.
                         existing_values = set(
-                            data_formatted[lexeme_id][field].split(", ")
+                            data_formatted[lexeme_id][field].split("| ")
                         )
                         existing_values.add(value)
-                        data_formatted[lexeme_id][field] = ", ".join(
+                        data_formatted[lexeme_id][field] = "| ".join(
                             sorted(existing_values)
                         )
 
@@ -88,12 +89,26 @@ def format_data(
     # Convert the dictionary to an ordered dictionary for consistent output.
     data_formatted = collections.OrderedDict(sorted(data_formatted.items()))
 
+    # Check if any values contain pipe separator before exporting.
+    for lexeme_data in data_formatted.values():
+        for value in lexeme_data.values():
+            if isinstance(value, str) and "| " in value:
+                has_multiple_forms = True
+                break
+        if has_multiple_forms:
+            break
+
     export_formatted_data(
         dir_path=dir_path,
         formatted_data=data_formatted,
         language=language,
         data_type=data_type,
     )
+
+    if has_multiple_forms:
+        print(
+            "Note: Multiple versions of forms have been returned. These have been combined with '|' in the resulting data fields."
+        )
 
     remove_queried_data(dir_path=dir_path, language=language, data_type=data_type)
 

--- a/src/scribe_data/wikidata/format_data.py
+++ b/src/scribe_data/wikidata/format_data.py
@@ -56,12 +56,13 @@ def format_data(
         # Initialize a new entry if this lexeme hasn't been seen yet.
         if lexeme_id not in data_formatted:
             data_formatted[lexeme_id] = {
-                key: value
-                for key, value in data_vals.items()
-                if key not in ["lexemeID", "lastModified"]
+                "lastModified": data_vals["lastModified"],
+                **{
+                    key: value
+                    for key, value in data_vals.items()
+                    if key not in ["lexemeID", "lastModified"]
+                },
             }
-
-            data_formatted[lexeme_id]["lastModified"] = data_vals["lastModified"]
 
         else:
             # Merge fields for an existing lexeme.

--- a/src/scribe_data/wikidata/parse_dump.py
+++ b/src/scribe_data/wikidata/parse_dump.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import List, Union
 
 import orjson
+from rich import print as rprint
 from tqdm import tqdm
 
 from scribe_data.utils import (
@@ -257,10 +258,10 @@ class LexemeProcessor:
                             for form_name, form_value in new_form_data.items():
                                 if form_name in existing_data:
                                     existing_values = set(
-                                        existing_data[form_name].split("| ")
+                                        existing_data[form_name].split(" | ")
                                     )
                                     existing_values.add(form_value)
-                                    existing_data[form_name] = "| ".join(
+                                    existing_data[form_name] = " | ".join(
                                         sorted(existing_values)
                                     )
                                 else:
@@ -541,13 +542,16 @@ class LexemeProcessor:
             try:
                 with open(output_file, "wb") as f:
                     f.write(orjson.dumps(filtered, option=orjson.OPT_INDENT_2))
+
                 print(
                     f"Successfully exported forms for {lang_name.capitalize()} {data_type} to {output_file}"
                 )
+
                 if has_multiple_forms:
-                    print(
-                        "Note: Multiple versions of forms have been returned. These have been combined with '|' in the resulting data fields."
+                    rprint(
+                        "[bold yellow]Note: Multiple versions of forms have been returned. These have been combined with '|' in the resulting data fields.[/bold yellow]"
                     )
+
             except Exception as e:
                 print(
                     f"Error saving forms for {lang_name.capitalize()} {data_type}: {e}"


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [X] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description
- Changed the separator from comma (", ") to pipe ("| ") in both `parse_dump.py` and `format_data.py` for better consistency and readability when merging multiple form values including lexeme dump.
- Added detection of multiple forms using the pipe separator and added appropriate warning messages in both files when multiple forms are found and merged.

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #573 
