### PR TITLE
Fix sub-language filter issue

### DIFF
--- a/src/scribe_data/check/check_missing_forms/generate_query.py
+++ b/src/scribe_data/check/check_missing_forms/generate_query.py
@@ -162,7 +162,7 @@ def generate_query(missing_features, query_dir=None, sub_lang_iso_code=None):
             forms_query.append({"label": concatenated_label, "qids": form_qids})
             used_labels.add(concatenated_label)
 
-    body_data_type = data_type.replace("_", "")[:-1]
+    body_data_type = data_type.replace("_", "")[:-1]  # nouns: noun, s
 
     # Generate a single query for all forms.
     main_body = f"""# tool: scribe-data
@@ -179,9 +179,9 @@ SELECT
 
 WHERE {{
   ?lexeme dct:language wd:{language_qid} ;
-      wikibase:lexicalCategory wd:{data_type_qid} ;
-      wikibase:lemma ?{body_data_type} ;
-      schema:dateModified ?lastModified .
+    wikibase:lexicalCategory wd:{data_type_qid} ;
+    wikibase:lemma ?{body_data_type} ;
+    schema:dateModified ?lastModified .
     """
     if sub_lang_iso_code:
         try:
@@ -197,7 +197,7 @@ WHERE {{
 
         where_clause += f"""
   # Note: We need to filter for {sub_lang_iso_code} to remove {sub_lang_name} ({sub_lang_iso_code}) words.
-  FILTER(lang(?{data_type}) = "{sub_lang_iso_code}")
+  FILTER(lang(?{body_data_type}) = "{sub_lang_iso_code}")
     """
 
     # Generate OPTIONAL clauses for all forms in one query.


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [X] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

In generating query filter, if we use data-type like nouns it gives us 0 results. Like [this query](https://query.wikidata.org/#%23%20tool%3A%20scribe-data%0A%23%20All%20Punjabi%20%28Q58635%29%20adjectives%20%28Q34698%29%20and%20the%20given%20forms.%0A%23%20Enter%20this%20query%20at%20https%3A%2F%2Fquery.wikidata.org%2F.%0A%0ASELECT%0A%20%20%28REPLACE%28STR%28%3Flexeme%29%2C%20%22http%3A%2F%2Fwww.wikidata.org%2Fentity%2F%22%2C%20%22%22%29%20AS%20%3FlexemeID%29%0A%20%20%3FlastModified%0A%20%20%3Fadjective%0A%20%20%3FdirectFeminineSingular%0A%20%20%3FdirectFemininePlural%0A%20%20%3FdirectFeminineSingularComparative%0A%20%20%3FdirectFeminineSingularPositive%0A%20%20%3FdirectFemininePluralComparative%0A%20%20%3FdirectFemininePluralPositive%0A%0AWHERE%20%7B%0A%20%20%3Flexeme%20dct%3Alanguage%20wd%3AQ58635%20%3B%0A%20%20%20%20wikibase%3AlexicalCategory%20wd%3AQ34698%20%3B%0A%20%20%20%20wikibase%3Alemma%20%3Fadjective%20%3B%0A%20%20%20%20schema%3AdateModified%20%3FlastModified%20.%0A%20%20%20%20%0A%20%20%23%20Note%3A%20We%20need%20to%20filter%20for%20pa%20to%20remove%20gurmukhi%20%28pa%29%20words.%0A%20%20FILTER%28lang%28%3Fadjectives%29%20%3D%20%22pa%22%29%0A%20%20%20%20%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20%3Flexeme%20ontolex%3AlexicalForm%20%3FdirectFeminineSingularForm%20.%0A%20%20%20%20%3FdirectFeminineSingularForm%20ontolex%3Arepresentation%20%3FdirectFeminineSingular%20%3B%0A%20%20%20%20%20%20wikibase%3AgrammaticalFeature%20wd%3AQ1751855%2C%20wd%3AQ1775415%2C%20wd%3AQ110786%20.%0A%20%20%7D%0A%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20%3Flexeme%20ontolex%3AlexicalForm%20%3FdirectFemininePluralForm%20.%0A%20%20%20%20%3FdirectFemininePluralForm%20ontolex%3Arepresentation%20%3FdirectFemininePlural%20%3B%0A%20%20%20%20%20%20wikibase%3AgrammaticalFeature%20wd%3AQ1751855%2C%20wd%3AQ1775415%2C%20wd%3AQ146786%20.%0A%20%20%7D%0A%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20%3Flexeme%20ontolex%3AlexicalForm%20%3FdirectFeminineSingularComparativeForm%20.%0A%20%20%20%20%3FdirectFeminineSingularComparativeForm%20ontolex%3Arepresentation%20%3FdirectFeminineSingularComparative%20%3B%0A%20%20%20%20%20%20wikibase%3AgrammaticalFeature%20wd%3AQ1751855%2C%20wd%3AQ1775415%2C%20wd%3AQ110786%2C%20wd%3AQ14169499%20.%0A%20%20%7D%0A%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20%3Flexeme%20ontolex%3AlexicalForm%20%3FdirectFeminineSingularPositiveForm%20.%0A%20%20%20%20%3FdirectFeminineSingularPositiveForm%20ontolex%3Arepresentation%20%3FdirectFeminineSingularPositive%20%3B%0A%20%20%20%20%20%20wikibase%3AgrammaticalFeature%20wd%3AQ1751855%2C%20wd%3AQ1775415%2C%20wd%3AQ110786%2C%20wd%3AQ3482678%20.%0A%20%20%7D%0A%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20%3Flexeme%20ontolex%3AlexicalForm%20%3FdirectFemininePluralComparativeForm%20.%0A%20%20%20%20%3FdirectFemininePluralComparativeForm%20ontolex%3Arepresentation%20%3FdirectFemininePluralComparative%20%3B%0A%20%20%20%20%20%20wikibase%3AgrammaticalFeature%20wd%3AQ1751855%2C%20wd%3AQ1775415%2C%20wd%3AQ146786%2C%20wd%3AQ14169499%20.%0A%20%20%7D%0A%0A%20%20OPTIONAL%20%7B%0A%20%20%20%20%3Flexeme%20ontolex%3AlexicalForm%20%3FdirectFemininePluralPositiveForm%20.%0A%20%20%20%20%3FdirectFemininePluralPositiveForm%20ontolex%3Arepresentation%20%3FdirectFemininePluralPositive%20%3B%0A%20%20%20%20%20%20wikibase%3AgrammaticalFeature%20wd%3AQ1751855%2C%20wd%3AQ1775415%2C%20wd%3AQ146786%2C%20wd%3AQ3482678%20.%0A%20%20%7D%0A%7D%0A)

So, we need to remove `s` at the end.
Also adjusted the spacing in `where_clause`.

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

 
