### PR TITLE
[FIX] - set default input_file if input_file is None

### DIFF
--- a/src/scribe_data/cli/convert.py
+++ b/src/scribe_data/cli/convert.py
@@ -223,8 +223,11 @@ def convert_to_csv_or_tsv(
     else:
         data_types = [dtype.strip() for dtype in data_type]
 
+    # Modify input file path to use the provided input_file or default JSON export path.
     input_file_path = (
-        Path(DEFAULT_JSON_EXPORT_DIR) / language.lower() / f"{data_types[0]}.json"
+        Path(input_file)
+        if input_file
+        else Path(DEFAULT_JSON_EXPORT_DIR) / language.lower() / f"{data_types[0]}.json"
     )
 
     for dtype in data_types:
@@ -255,6 +258,7 @@ def convert_to_csv_or_tsv(
 
         output_file = final_output_dir / f"{dtype}.{output_type}"
 
+        # Use check_index_exists to determine if file should be processed.
         file_exist = check_index_exists(output_file, overwrite)
 
         if file_exist:

--- a/src/scribe_data/cli/convert.py
+++ b/src/scribe_data/cli/convert.py
@@ -120,8 +120,10 @@ def convert_to_json(
                         for row in rows:
                             if identifier_case == "snake":
                                 key = camel_to_snake(row.get(reader.fieldnames[0]))
+
                             else:
                                 key = row.get(reader.fieldnames[0])
+
                             emoji = row.get("emoji", "").strip()
                             is_base = (
                                 row.get("is_base", "false").strip().lower() == "true"
@@ -133,6 +135,7 @@ def convert_to_json(
 
                             if key not in data:
                                 data[key] = []
+
                             data[key].append(entry)
 
                     else:
@@ -154,9 +157,7 @@ def convert_to_json(
         # Define output file path
         output_file = json_output_dir / f"{dtype}.{output_type}"
 
-        file_exist = check_index_exists(output_file, overwrite)
-
-        if file_exist:
+        if check_index_exists(output_file, overwrite):
             print(f"Skipping {dtype}")
             continue
 
@@ -258,10 +259,7 @@ def convert_to_csv_or_tsv(
 
         output_file = final_output_dir / f"{dtype}.{output_type}"
 
-        # Use check_index_exists to determine if file should be processed.
-        file_exist = check_index_exists(output_file, overwrite)
-
-        if file_exist:
+        if check_index_exists(output_file, overwrite):
             print(f"Skipping {dtype}")
             continue
 
@@ -311,12 +309,14 @@ def convert_to_csv_or_tsv(
                                             item.get("rank", ""),
                                         ]
                                         writer.writerow(row)
+
                             else:
                                 if identifier_case == "snake":
                                     columns = [camel_to_snake(dtype[:-1])] + [
                                         camel_to_snake(col)
                                         for col in data[first_key][0].keys()
                                     ]
+
                                 else:
                                     writer.writerow(columns)
                                 writer.writerow(columns)
@@ -354,6 +354,7 @@ def convert_to_csv_or_tsv(
                                 "value",
                             ]
                         )
+
                         for key, value in data.items():
                             writer.writerow([key, value])
 

--- a/src/scribe_data/cli/convert.py
+++ b/src/scribe_data/cli/convert.py
@@ -74,7 +74,8 @@ def convert_to_json(
         input_file_path = Path(input_file)
 
         if not input_file_path.exists():
-            raise FileNotFoundError(f"Input file '{input_file_path}' does not exist.")
+            print(f"No data found for {dtype} conversion at '{input_file_path}'.")
+            continue
 
         delimiter = {".csv": ",", ".tsv": "\t"}.get(input_file_path.suffix.lower())
 
@@ -405,6 +406,21 @@ def convert_wrapper(
     None
         This function does not return any value; it performs a conversion operation.
     """
+
+    # Set default input file source
+    if input_files is None:
+        csv_file = f"{DEFAULT_CSV_EXPORT_DIR}/{languages}/{data_types}.csv"
+        tsv_file = f"{DEFAULT_TSV_EXPORT_DIR}/{languages}/{data_types}.tsv"
+
+        csv_exists = Path(csv_file).exists()
+        json_source = csv_file if csv_exists else tsv_file
+
+        input_files = {
+            "csv": f"{DEFAULT_JSON_EXPORT_DIR}/{languages}/{data_types}.json",
+            "json": f"{json_source}",
+            "sqlite": f"{DEFAULT_JSON_EXPORT_DIR}/{languages}/{data_types}.json",
+            "tsv": f"{DEFAULT_JSON_EXPORT_DIR}/{languages}/{data_types}.json",
+        }.get(output_type, f"{DEFAULT_JSON_EXPORT_DIR}/{languages}/{data_types}.json")
 
     # Route the function call to the correct conversion function.
     if output_type == "json":


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description


Setting default input file for when input file param is not given (None)
These commands should work as expected now.
```bash
scribe-data get --language English --data-type verbs
scribe-data c -lang english -dt verbs -ot csv 
```


### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #588
