### PR TITLE
Update pre-commit config and SPARQL queries for Igbo adjectives

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,12 +23,11 @@ repos:
     hooks:
       - id: ruff
         args: [--fix]
-
       - id: ruff-format
 
-  # - repo: https://github.com/numpy/numpydoc
-  #   rev: v1.8.0
-  #   hooks:
-  #     - id: numpydoc-validation
-  #       files: ^src/
-  #       exclude: ^tests/
+  - repo: https://github.com/numpy/numpydoc
+    rev: v1.8.0
+    hooks:
+      - id: numpydoc-validation
+        files: ^src/
+        exclude: ^tests/|src/scribe_data/check/check_query_forms.py|src/scribe_data/cli/interactive.py|src/scribe_data/load/data_to_sqlite.py|src/scribe_data/wikidata/parse_dump.py|src/scribe_data/utils.py|src/scribe_data/cli/cli_utils.py|src/scribe_data/cli/download.py|src/scribe_data/cli/get.py|src/scribe_data/cli/list.py|src/scribe_data/cli/version.py|src/scribe_data/check/.*|src/scribe_data/check/check_missing_forms/.*|src/scribe_data/cli/.*|src/scribe_data/load/.*|src/scribe_data/wikidata/.*|src/scribe_data/wikidata/check_query/.*|src/scribe_data/unicode/.*|src/.*__init__.py$

--- a/src/scribe_data/wikidata/language_data_extraction/igbo/adjectives/query_adjectives_1.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/igbo/adjectives/query_adjectives_1.sparql
@@ -8,23 +8,18 @@ SELECT
   ?adjective
   ?singular
   ?plural
-
 WHERE {
   ?lexeme dct:language wd:Q33578;
     wikibase:lexicalCategory wd:Q34698;
     wikibase:lemma ?adjective ;
     schema:dateModified ?lastModified .
-
   # MARK: Singular
-
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?singularForm .
     ?singularForm ontolex:representation ?singular ;
       wikibase:grammaticalFeature wd:Q110786 .
   }
-
   # MARK: Plural
-
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?pluralForm .
     ?pluralForm ontolex:representation ?plural ;

--- a/src/scribe_data/wikidata/language_data_extraction/igbo/adjectives/query_adjectives_2.sparql
+++ b/src/scribe_data/wikidata/language_data_extraction/igbo/adjectives/query_adjectives_2.sparql
@@ -1,7 +1,6 @@
 # tool: scribe-data
 # All Igbo (Q33578) adjectives (Q34698) and the given forms.
 # Enter this query at https://query.wikidata.org/.
-
 SELECT
   (REPLACE(STR(?lexeme), "http://www.wikidata.org/entity/", "") AS ?lexemeID)
   ?lastModified
@@ -12,43 +11,36 @@ SELECT
   ?comparative
   ?superlative
   ?singularPlural
-
 WHERE {
   ?lexeme dct:language wd:Q33578 ;
     wikibase:lexicalCategory wd:Q34698 ;
     wikibase:lemma ?adjective ;
     schema:dateModified ?lastModified .
-    
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?presentContinuousForm .
     ?presentContinuousForm ontolex:representation ?presentContinuous ;
       wikibase:grammaticalFeature wd:Q7240943 .
   }
-
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?combinedPresentParticipleForm .
     ?combinedPresentParticipleForm ontolex:representation ?combinedPresentParticiple ;
       wikibase:grammaticalFeature wd:Q10345583 .
   }
-
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?combinedPastParticipleForm .
     ?combinedPastParticipleForm ontolex:representation ?combinedPastParticiple ;
       wikibase:grammaticalFeature wd:Q12717679 .
   }
-
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?comparativeForm .
     ?comparativeForm ontolex:representation ?comparative ;
       wikibase:grammaticalFeature wd:Q14169499 .
   }
-
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?superlativeForm .
     ?superlativeForm ontolex:representation ?superlative ;
       wikibase:grammaticalFeature wd:Q1817208 .
   }
-
   OPTIONAL {
     ?lexeme ontolex:lexicalForm ?singularPluralForm .
     ?singularPluralForm ontolex:representation ?singularPlural ;


### PR DESCRIPTION
### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### PR Description:
This pull request includes the following changes:

- Updated the `.pre-commit-config.yaml` file to improve the pre-commit hooks setup.
- Modified two SPARQL queries (`query_adjectives_1.sparql` and `query_adjectives_2.sparql`) for retrieving information related to Igbo adjectives and their grammatical forms, including comparative, superlative, and participle forms.

- #ISSUE_NUMBER
   547