### PR TITLE
Fix failing CLI tests by mocking interactive prompt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements-dev.in
 #
-absl-py==2.1.0
+absl-py==2.3.0
     # via
     #   chex
     #   optax
@@ -13,23 +13,23 @@ alabaster==1.0.0
     # via sphinx
 babel==2.17.0
     # via sphinx
-beautifulsoup4==4.9.3
+beautifulsoup4==4.13.4
     # via -r requirements-dev.in
 build==1.2.2.post1
     # via pip-tools
-certifi==2025.1.31
+certifi==2025.6.15
     # via
     #   -r requirements-dev.in
     #   requests
 cfgv==3.4.0
     # via pre-commit
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
 chex==0.1.89
     # via optax
-click==8.1.8
+click==8.2.1
     # via pip-tools
-coverage[toml]==7.6.12
+coverage[toml]==7.9.1
     # via pytest-cov
 defusedxml==0.7.1
     # via -r requirements-dev.in
@@ -42,19 +42,17 @@ docutils==0.21.2
     #   sphinx-rtd-theme
 emoji==2.14.1
     # via -r requirements-dev.in
-etils[epath,epy]==1.12.0
-    # via
-    #   optax
-    #   orbax-checkpoint
-filelock==3.17.0
+etils[epath,epy]==1.12.2
+    # via orbax-checkpoint
+filelock==3.18.0
     # via virtualenv
 flax==0.10.4
     # via -r requirements-dev.in
-fsspec==2025.2.0
+fsspec==2025.5.1
     # via etils
-humanize==4.12.1
+humanize==4.12.3
     # via orbax-checkpoint
-identify==2.6.8
+identify==2.6.12
     # via pre-commit
 idna==3.10
     # via requests
@@ -62,24 +60,24 @@ imagesize==1.4.1
     # via sphinx
 importlib-resources==6.5.2
     # via etils
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
-iso639-lang==2.6.0
+iso639-lang==2.6.1
     # via -r requirements-dev.in
-jax==0.5.2
+jax==0.4.38
     # via
     #   chex
     #   flax
     #   optax
     #   orbax-checkpoint
-jaxlib==0.5.1
+jaxlib==0.4.38
     # via
     #   chex
     #   jax
     #   optax
 jinja2==3.1.6
     # via sphinx
-m2r2==0.3.3.post2
+m2r2==0.3.4
     # via -r requirements-dev.in
 markdown-it-py==3.0.0
     # via rich
@@ -94,21 +92,21 @@ ml-dtypes==0.5.1
     #   jax
     #   jaxlib
     #   tensorstore
-msgpack==1.1.0
+msgpack==1.1.1
     # via
     #   flax
     #   orbax-checkpoint
 mwparserfromhell==0.6.6
     # via -r requirements-dev.in
-mypy==1.15.0
+mypy==1.16.1
     # via -r requirements-dev.in
-mypy-extensions==1.0.0
+mypy-extensions==1.1.0
     # via mypy
 nest-asyncio==1.6.0
     # via orbax-checkpoint
 nodeenv==1.9.1
     # via pre-commit
-numpy==2.2.3
+numpy==2.3.1
     # via
     #   chex
     #   flax
@@ -121,55 +119,60 @@ numpy==2.2.3
     #   scipy
     #   tensorstore
     #   treescope
-numpydoc==1.8.0
+numpydoc==1.9.0
     # via -r requirements-dev.in
 opt-einsum==3.4.0
     # via jax
-optax==0.2.4
+optax==0.2.5
     # via flax
-orbax-checkpoint==0.11.6
+orbax-checkpoint==0.11.5
     # via flax
-orjson==3.10.15
+orjson==3.10.18
     # via -r requirements-dev.in
-packaging==24.2
+packaging==25.0
     # via
     #   -r requirements-dev.in
     #   build
     #   pytest
     #   sphinx
-pandas==2.2.3
+pandas==2.3.0
     # via -r requirements-dev.in
+pathspec==0.12.1
+    # via mypy
 pip-tools==7.4.1
     # via -r requirements-dev.in
-platformdirs==4.3.6
+platformdirs==4.3.8
     # via virtualenv
-pluggy==1.5.0
-    # via pytest
-pre-commit==4.1.0
+pluggy==1.6.0
+    # via
+    #   pytest
+    #   pytest-cov
+pre-commit==4.2.0
     # via -r requirements-dev.in
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via questionary
 protobuf==6.31.1
     # via orbax-checkpoint
-pygments==2.19.1
+pygments==2.19.2
     # via
+    #   pytest
     #   rich
     #   sphinx
-pyparsing==3.2.1
+pyparsing==3.2.3
     # via rdflib
 pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-pytest==8.3.5
+pytest==8.4.1
     # via
     #   -r requirements-dev.in
     #   pytest-cov
-pytest-cov==6.0.0
+pytest-cov==6.2.1
     # via -r requirements-dev.in
 python-dateutil==2.9.0.post0
     # via pandas
-pytz==2025.1
+pytz==2025.2
     # via pandas
 pyyaml==6.0.2
     # via
@@ -178,7 +181,7 @@ pyyaml==6.0.2
     #   pre-commit
 questionary==2.1.0
     # via -r requirements-dev.in
-rdflib==7.1.3
+rdflib==7.1.4
     # via sparqlwrapper
 regex==2024.11.6
     # via -r requirements-dev.in
@@ -186,15 +189,15 @@ requests==2.32.4
     # via
     #   -r requirements-dev.in
     #   sphinx
-rich==13.9.4
+rich==14.0.0
     # via
     #   -r requirements-dev.in
     #   flax
 roman-numerals-py==3.1.0
     # via sphinx
-ruff==0.9.9
+ruff==0.12.0
     # via -r requirements-dev.in
-scipy==1.15.2
+scipy==1.16.0
     # via
     #   jax
     #   jaxlib
@@ -202,9 +205,9 @@ simplejson==3.20.1
     # via orbax-checkpoint
 six==1.17.0
     # via python-dateutil
-snowballstemmer==2.2.0
+snowballstemmer==3.0.1
     # via sphinx
-soupsieve==2.6
+soupsieve==2.7
     # via beautifulsoup4
 sparqlwrapper==2.0.0
     # via -r requirements-dev.in
@@ -229,36 +232,35 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-tabulate==0.9.0
-    # via numpydoc
-tensorstore==0.1.72
+tensorstore==0.1.75
     # via
     #   flax
     #   orbax-checkpoint
 toolz==1.0.0
     # via chex
-tqdm==4.66.4
+tqdm==4.67.1
     # via -r requirements-dev.in
 treescope==0.1.9
     # via flax
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
+    #   beautifulsoup4
     #   chex
     #   etils
     #   flax
     #   mypy
     #   orbax-checkpoint
-tzdata==2025.1
+tzdata==2025.2
     # via pandas
 urllib3==2.5.0
     # via requests
-virtualenv==20.29.2
+virtualenv==20.31.2
     # via pre-commit
 wcwidth==0.2.13
     # via prompt-toolkit
 wheel==0.45.1
     # via pip-tools
-zipp==3.21.0
+zipp==3.23.0
     # via etils
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,18 +4,18 @@
 #
 #    pip-compile requirements.in
 #
-absl-py==2.1.0
+absl-py==2.3.0
     # via
     #   chex
     #   optax
     #   orbax-checkpoint
-beautifulsoup4==4.9.3
+beautifulsoup4==4.13.4
     # via -r requirements.in
-certifi==2025.1.31
+certifi==2025.6.15
     # via
     #   -r requirements.in
     #   requests
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
 chex==0.1.89
     # via optax
@@ -23,29 +23,27 @@ defusedxml==0.7.1
     # via -r requirements.in
 emoji==2.14.1
     # via -r requirements.in
-etils[epath,epy]==1.12.0
-    # via
-    #   optax
-    #   orbax-checkpoint
+etils[epath,epy]==1.12.2
+    # via orbax-checkpoint
 flax==0.10.4
     # via -r requirements.in
-fsspec==2025.2.0
+fsspec==2025.5.1
     # via etils
-humanize==4.12.1
+humanize==4.12.3
     # via orbax-checkpoint
 idna==3.10
     # via requests
 importlib-resources==6.5.2
     # via etils
-iso639-lang==2.6.0
+iso639-lang==2.6.1
     # via -r requirements.in
-jax==0.5.2
+jax==0.4.38
     # via
     #   chex
     #   flax
     #   optax
     #   orbax-checkpoint
-jaxlib==0.5.1
+jaxlib==0.4.38
     # via
     #   chex
     #   jax
@@ -59,7 +57,7 @@ ml-dtypes==0.5.1
     #   jax
     #   jaxlib
     #   tensorstore
-msgpack==1.1.0
+msgpack==1.1.1
     # via
     #   flax
     #   orbax-checkpoint
@@ -67,7 +65,7 @@ mwparserfromhell==0.6.6
     # via -r requirements.in
 nest-asyncio==1.6.0
     # via orbax-checkpoint
-numpy==2.2.3
+numpy==2.3.1
     # via
     #   chex
     #   flax
@@ -82,27 +80,27 @@ numpy==2.2.3
     #   treescope
 opt-einsum==3.4.0
     # via jax
-optax==0.2.4
+optax==0.2.5
     # via flax
-orbax-checkpoint==0.11.6
+orbax-checkpoint==0.11.5
     # via flax
-orjson==3.10.15
+orjson==3.10.18
     # via -r requirements.in
-packaging==24.2
+packaging==25.0
     # via -r requirements.in
-pandas==2.2.3
+pandas==2.3.0
     # via -r requirements.in
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via questionary
 protobuf==6.31.1
     # via orbax-checkpoint
-pygments==2.19.1
+pygments==2.19.2
     # via rich
-pyparsing==3.2.1
+pyparsing==3.2.3
     # via rdflib
 python-dateutil==2.9.0.post0
     # via pandas
-pytz==2025.1
+pytz==2025.2
     # via pandas
 pyyaml==6.0.2
     # via
@@ -110,17 +108,17 @@ pyyaml==6.0.2
     #   orbax-checkpoint
 questionary==2.1.0
     # via -r requirements.in
-rdflib==7.1.3
+rdflib==7.1.4
     # via sparqlwrapper
 regex==2024.11.6
     # via -r requirements.in
 requests==2.32.4
     # via -r requirements.in
-rich==13.9.4
+rich==14.0.0
     # via
     #   -r requirements.in
     #   flax
-scipy==1.15.2
+scipy==1.16.0
     # via
     #   jax
     #   jaxlib
@@ -128,33 +126,34 @@ simplejson==3.20.1
     # via orbax-checkpoint
 six==1.17.0
     # via python-dateutil
-soupsieve==2.6
+soupsieve==2.7
     # via beautifulsoup4
 sparqlwrapper==2.0.0
     # via -r requirements.in
-tensorstore==0.1.72
+tensorstore==0.1.75
     # via
     #   flax
     #   orbax-checkpoint
 toolz==1.0.0
     # via chex
-tqdm==4.66.4
+tqdm==4.67.1
     # via -r requirements.in
 treescope==0.1.9
     # via flax
-typing-extensions==4.12.2
+typing-extensions==4.14.0
     # via
+    #   beautifulsoup4
     #   chex
     #   etils
     #   flax
     #   orbax-checkpoint
-tzdata==2025.1
+tzdata==2025.2
     # via pandas
 urllib3==2.5.0
     # via requests
 wcwidth==0.2.13
     # via prompt-toolkit
-zipp==3.21.0
+zipp==3.23.0
     # via etils
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/tests/cli/test_get.py
+++ b/tests/cli/test_get.py
@@ -515,10 +515,13 @@ class TestGetData(unittest.TestCase):
                 )
 
     @patch("scribe_data.cli.get.query_data")
-    def test_get_data_with_interactive_mode(self, mock_query_data):
+    @patch("scribe_data.cli.get.check_index_exists")
+    def test_get_data_with_interactive_mode(self, mock_check_exists, mock_query_data):
         """
         Test retrieving data in interactive mode.
         """
+        mock_check_exists.return_value = False
+
         get_data(language="English", data_type="nouns", interactive=True)
 
         mock_query_data.assert_called_once_with(
@@ -599,10 +602,13 @@ class TestGetData(unittest.TestCase):
         )
 
     @patch("scribe_data.cli.get.query_data")
-    def test_get_data_case_insensitive_type(self, mock_query_data):
+    @patch("scribe_data.cli.get.check_index_exists")
+    def test_get_data_case_insensitive_type(self, mock_check_exists, mock_query_data):
         """
         Test that data type is case insensitive.
         """
+        mock_check_exists.return_value = False
+
         get_data(language="English", data_type="NOUNS")
 
         mock_query_data.assert_called_once_with(


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

Patched `check_index_exists` in two test cases to prevent EOFError caused by interactive prompts in non-interactive environments. This ensures tests for `get_data()` run smoothly in CI by simulating prompt behaviour.

### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- closes #621 
