### PR TITLE
fix: contract dir path conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
 
 ### 🐞 Bug Fixes
 
-- The path to the contracts was fixed in data filtration to assure that it's a `pathlib.Path` value ([#624](https://github.com/scribe-org/Scribe-Data/issues/624)).
+- The path to the contracts was fixed in data filtration to assure that it's a `pathlib.Path` value ([#627](https://github.com/scribe-org/Scribe-Data/issues/627)).
 
 ### ✅ Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
 
 ## [Upcoming] Scribe-Data 5.x
 
+### 🐞 Bug Fixes
+
+- The path to the contracts was fixed in data filtration to assure that it's a `pathlib.Path` value ([#624](https://github.com/scribe-org/Scribe-Data/issues/624)).
+
 ### ✅ Tests
 
 - The upgrade functionality of the CLI is now comprehensively tested ([#624](https://github.com/scribe-org/Scribe-Data/issues/624)).

--- a/src/scribe_data/cli/contracts/filter.py
+++ b/src/scribe_data/cli/contracts/filter.py
@@ -264,6 +264,8 @@ def export_data_filtered_by_contracts(
 
     if not contracts_dir:
         contracts_dir = scribe_data_contracts
+    else:
+        contracts_dir = Path(contracts_dir)
 
     for contract_filename in os.listdir(contracts_dir):
         if not contract_filename.endswith(".json"):

--- a/src/scribe_data/cli/contracts/filter.py
+++ b/src/scribe_data/cli/contracts/filter.py
@@ -262,10 +262,7 @@ def export_data_filtered_by_contracts(
 
     input_dir = input_dir or DEFAULT_JSON_EXPORT_DIR
 
-    if not contracts_dir:
-        contracts_dir = scribe_data_contracts
-    else:
-        contracts_dir = Path(contracts_dir)
+    contracts_dir = Path(contracts_dir) if contracts_dir else scribe_data_contracts
 
     for contract_filename in os.listdir(contracts_dir):
         if not contract_filename.endswith(".json"):


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

This PR ensures that `contracts_dir` is always a `Path` object.  
Previously, if a string path was passed, it caused issues when using `/` path operations.  
Now, we convert `contracts_dir` to `Path` when provided.

### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- closes #627 