### PR TITLE
Fix `scribe-data convert -l` for Multiple Languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
 
 ## [Upcoming] Scribe-Data 5.x
 
+## Scribe-Data 5.1.2
+
+### 🐞 Bug Fixes
+
+- Fixed data conversion not handling multiple explicitly passed languages ([#630](https://github.com/scribe-org/Scribe-Data/issues/630)).
+
 ## Scribe-Data 5.1.1
 
 ### 🐞 Bug Fixes

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ copyright = "2024, Scribe-Data developers (GPL 3.0 License)"
 author = "Scribe-Data developers"
 
 # The full version, including alpha/beta/rc tags
-release = "5.1.1"
+release = "5.1.2"
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup_args = dict(
     name="scribe-data",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
-    version="5.1.1",
+    version="5.1.2",
     author="Andrew Tavis McAllister",
     author_email="team@scri.be",
     classifiers=[

--- a/src/scribe_data/cli/main.py
+++ b/src/scribe_data/cli/main.py
@@ -241,7 +241,7 @@ def main() -> None:
     convert_parser.add_argument(
         "-lang",
         "--language",
-        nargs='+',
+        nargs="+",
         type=str,
         required=False,
         help="The language of the file to convert.",
@@ -486,15 +486,16 @@ def main() -> None:
             if args.interactive:
                 start_interactive_mode(operation="convert")
                 return
-            
-            # Handle language(s) - could be string or list
+
+            # Handle language(s) - could be string or list.
             languages = None
             if args.language is not None:
                 if isinstance(args.language, list):
                     languages = [lang.lower() for lang in args.language]
+
                 else:
                     languages = args.language.lower()
-                
+
             convert_wrapper(
                 languages=languages,
                 data_types=args.data_type.lower()

--- a/src/scribe_data/load/data_to_sqlite.py
+++ b/src/scribe_data/load/data_to_sqlite.py
@@ -211,8 +211,10 @@ def data_to_sqlite(
 
     if not languages:
         languages = current_languages
+
     elif isinstance(languages, str):
         languages = [languages.lower()]
+
     elif isinstance(languages, list):
         languages = [lang.lower() for lang in languages]
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

Fixes `scribe-data convert -l` failing for multiple languages (unrecognised arguments) and single valid languages like French (ValueError).

Changes:
- Updated `convert_wrapper` and the `convert_parser` to parse multiple languages (e.g., -l english, french).
- Fixed `data_to_sqlite` to validate languages correctly.



### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- Closes #630 
