### PR TITLE
allow multi-datatype-passes for `convert_parser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
 
 ## [Upcoming] Scribe-Data 5.x
 
+## Scribe-Data 5.1.4
+
+### 🐞 Bug Fixes
+
+- Allow the convert parser to accept multiple data types ([#634](https://github.com/scribe-org/Scribe-Data/issues/634)).
+
 ## Scribe-Data 5.1.3
 
 ### 🐞 Bug Fixes

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ copyright = "2024, Scribe-Data developers (GPL 3.0 License)"
 author = "Scribe-Data developers"
 
 # The full version, including alpha/beta/rc tags
-release = "5.1.3"
+release = "5.1.4"
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup_args = dict(
     name="scribe-data",
     packages=find_packages(where="src"),
     package_dir={"": "src"},
-    version="5.1.3",
+    version="5.1.4",
     author="Andrew Tavis McAllister",
     author_email="team@scri.be",
     classifiers=[

--- a/src/scribe_data/cli/main.py
+++ b/src/scribe_data/cli/main.py
@@ -247,17 +247,17 @@ def main() -> None:
         "-lang",
         "--language",
         type=str,
-        nargs="+",
         required=False,
         help="The language of the file to convert.",
+        nargs="+",
     )
     convert_parser.add_argument(
         "-dt",
         "--data-type",
         type=str,
-        nargs="+",
         required=False,
         help="The data type(s) of the file to convert (e.g., nouns, verbs).",
+        nargs="+",
     )
     convert_parser.add_argument(
         "-if",
@@ -537,11 +537,12 @@ def main() -> None:
 
             data_types = None
             if args.data_type is not None:
-                if isinstance(args.data_type, list):
-                    data_types = [dt.lower() for dt in args.data_type]
-                else:
-                    data_types = args.data_type.lower()
-                    
+                data_types = (
+                    [dt.lower() for dt in args.data_type]
+                    if isinstance(args.data_type, list)
+                    else args.data_type.lower()
+                )
+
             convert_wrapper(
                 languages=languages,
                 data_types=data_types,

--- a/src/scribe_data/cli/main.py
+++ b/src/scribe_data/cli/main.py
@@ -247,14 +247,15 @@ def main() -> None:
         "-lang",
         "--language",
         type=str,
+        nargs="+",
         required=False,
         help="The language of the file to convert.",
-        nargs="+",
     )
     convert_parser.add_argument(
         "-dt",
         "--data-type",
         type=str,
+        nargs="+",
         required=False,
         help="The data type(s) of the file to convert (e.g., nouns, verbs).",
     )
@@ -534,11 +535,16 @@ def main() -> None:
                 else:
                     languages = args.language.lower()
 
+            data_types = None
+            if args.data_type is not None:
+                if isinstance(args.data_type, list):
+                    data_types = [dt.lower() for dt in args.data_type]
+                else:
+                    data_types = args.data_type.lower()
+                    
             convert_wrapper(
                 languages=languages,
-                data_types=args.data_type.lower()
-                if args.data_type is not None
-                else None,
+                data_types=data_types,
                 output_type=args.output_type,
                 input_files=args.input_file,
                 output_dir=args.output_dir,


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- closes #634 
