### PR TITLE
Bugfix/path error for dump

### DIFF
--- a/src/scribe_data/wikipedia/generate_autosuggestions.py
+++ b/src/scribe_data/wikipedia/generate_autosuggestions.py
@@ -73,7 +73,6 @@ def generate_autosuggestions(language, dump_id, force_download):
         verbose=True,
     )
 
-    # This should be "output_path" because when dump_id is given as arg , it looks for right path to make partitions_dir
     with open(output_path, "r") as fin:
         article_texts = [
             json.loads(lang)[1]


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

**The Problem:** When `scribe-data get --language English --data-type autosuggestions ` is used as a command to make `enwiki_dump` files, everything is perfect but when `scribe-data get --language English --data-type autosuggestions --dump-id 20250820` is used along with dump-id (the date), the path is not recognised because this was unable to make partitions using the right path.

**The Fix**: We have to show the right path when the dump id is given, so if no dump-id all good, when dump-id then show right path to make partitions

**Tests:** Tests are passed , for the commits that I have made 👇

<img width="1007" height="387" alt="Screenshot 2025-10-09 at 4 28 07 PM" src="https://github.com/user-attachments/assets/1eb9907c-7af1-4a3c-9924-65a536671006" />

Disclaimer: I fixed this issue while trying to solve this [Scribe-iOS issue#523](https://github.com/scribe-org/Scribe-iOS/issues/523#issuecomment-3380601247)


@andrewtavis  @DeleMike @henrikth93  Thanks for the Opportunity !

###

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

###
