### PR TITLE
Fix/parsing logic error for sax

### DIFF
--- a/src/scribe_data/wikipedia/extract_wiki.py
+++ b/src/scribe_data/wikipedia/extract_wiki.py
@@ -464,10 +464,6 @@ class WikiXmlHandler(xml.sax.handler.ContentHandler):
         self._current_tag = None
         self.target_articles = []
 
-    # Added the missing logic here ...
-    # Need startelement, endelement and characters to extract the text inside
-    # Sax must go through lines and trigger the callbacks so define them with start, end and characters
-
     def startElement(self, name, attrs):
         """
         Handle the start of an XML element.
@@ -500,22 +496,22 @@ class WikiXmlHandler(xml.sax.handler.ContentHandler):
             title = self._values.get("title", "")
             text = self._values.get("text", "")
 
-        # Filter out redirect pages and special pages
-        if (
-            text
-            and not text.strip().startswith("#REDIRECT")
-            and not text.strip().startswith("#redirect")
-            and ":" not in title
-        ):  # Skip namespace pages
-            processed_title, processed_text = _process_article(title, text)
+            # Filter out redirect pages and special pages
+            if (
+                text
+                and not text.strip().startswith("#REDIRECT")
+                and not text.strip().startswith("#redirect")
+                and ":" not in title
+            ):  # Skip namespace pages
+                processed_title, processed_text = _process_article(title, text)
 
-            if processed_text and len(processed_text) > 100:  # Minimum text length
-                self.target_articles.append([processed_title, processed_text])
+                if processed_text and len(processed_text) > 100:  # Minimum text length
+                    self.target_articles.append([processed_title, processed_text])
 
-        # Reset values for next page, clear up for next page
-        self._values = {}
-        self._buffer = None
-        self._current_tag = None
+            # Reset values for next page, clear up for next page
+            self._values = {}
+            self._buffer = None
+            self._current_tag = None
 
     def characters(self, content):
         """

--- a/src/scribe_data/wikipedia/generate_autosuggestions.py
+++ b/src/scribe_data/wikipedia/generate_autosuggestions.py
@@ -73,7 +73,7 @@ def generate_autosuggestions(language, dump_id, force_download):
         verbose=True,
     )
 
-    with open(output_path, "r") as fin:
+    with open(output_path, "r", encoding="utf-8") as fin:
         article_texts = [
             json.loads(lang)[1]
             for lang in tqdm(fin, desc="Articles added", unit="articles")
@@ -101,3 +101,13 @@ def generate_autosuggestions(language, dump_id, force_download):
         update_local_data=True,
         verbose=True,
     )
+
+
+# Uncomment to test
+"""if __name__ == "__main__":
+    generate_autosuggestions(
+        language="english",
+        dump_id="20250520",
+        force_download=False,
+        file_limit=1  # limiting test with just 1 file
+    )"""


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

### **Fix:** 

The enwiki's ".ndjson" was always parsing without any data, and this is because the parser is unable to open the file elements to parse like for example " `<page> <title> Heading For The Article </title> </page>` is not being read and called back to parse the array of articles/words that we need. So I have added the missing callback triggers for reading the texts inside those tags.

added filtering to omit the redirect links to various sources and name space pages

I have also verified it by downloading 2 enwiki_dump files and trying to parse them into words 👇

@axif0 @andrewtavis  @DeleMike Please have a look and lemme know if there are any corrections to be made or if my approach in understanding the issue is wrong

<img width="843" height="423" alt="image" src="https://github.com/user-attachments/assets/f6a04399-9bf6-4565-8fa5-738ae1ff53a4" />






<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

#641 
