### PR TITLE
fix: process all JSON data types during contract filtering

### DIFF
--- a/src/scribe_data/cli/contracts/filter.py
+++ b/src/scribe_data/cli/contracts/filter.py
@@ -292,13 +292,13 @@ def export_data_filtered_by_contracts(
             print(f"No input directory found for {matched_language}")
             continue
 
-        data_files = [f for f in lang_input_dir.glob("*.json")]
+        data_files = list(lang_input_dir.glob("*.json"))
         for input_file in data_files:
             data_type = (
                 input_file.stem
             )  # e.g., nouns, verbs, prepositions, translations
 
-            # Skip unsupported types if needed
+            # Skip unsupported types if needed.
             if data_type not in contract_metadata:
                 output_file = (
                     export_dir
@@ -306,6 +306,7 @@ def export_data_filtered_by_contracts(
                     / f"{data_type}.json"
                 )
                 output_file.parent.mkdir(parents=True, exist_ok=True)
+
                 with (
                     open(input_file, "r", encoding="utf-8") as src,
                     open(output_file, "w", encoding="utf-8") as dst,
@@ -314,7 +315,7 @@ def export_data_filtered_by_contracts(
                 print(f"Copied unfiltered {data_type} for {matched_language}")
                 continue
 
-            # Filter if contract metadata exists
+            # Filter if contract metadata exists.
             if filtered_data := filter_exported_data(
                 input_file, contract_metadata, data_type
             ):

--- a/tests/cli/contracts/test_contracts_export.py
+++ b/tests/cli/contracts/test_contracts_export.py
@@ -272,9 +272,9 @@ class TestExportContracts:
             "spanish": "Spanish",
         }.get(lang)
 
-        # Mock exists to return True for language directories
+        # Mock exists to return True for language directories.
         def exists_side_effect():
-            # This is called on Path instances, check if it's a language directory
+            # This is called on Path instances, check if it's a language directory.
             return True
 
         mock_exists.side_effect = exists_side_effect
@@ -302,18 +302,22 @@ class TestExportContracts:
         ] * 2  # for both languages
 
         def mock_path_glob(self, pattern):
-            """Mock glob method that returns files based on the path"""
+            """
+            Mock glob method that returns files based on the path.
+            """
             path_str = str(self)
             if "english" in path_str.lower():
                 return [
                     Path("test_input/english/nouns.json"),
                     Path("test_input/english/verbs.json"),
                 ]
+
             elif "spanish" in path_str.lower():
                 return [
                     Path("test_input/spanish/nouns.json"),
                     Path("test_input/spanish/verbs.json"),
                 ]
+
             return []
 
         with patch.object(Path, "glob", mock_path_glob):
@@ -397,7 +401,7 @@ class TestExportContracts:
         with patch("builtins.print") as mock_print:
             export_data_filtered_by_contracts()
 
-            # Verify warning was printed - expects "No input directory found for English"
+            # Verify warning was printed - expects "No input directory found for English".
             assert mock_print.call_count >= 1
             mock_print.assert_called_with("No input directory found for English")
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- closes #644 