### PR TITLE
speed up autosuggestions generation by building bigram counts in a si…

### DIFF
--- a/src/scribe_data/wikipedia/process_wiki.py
+++ b/src/scribe_data/wikipedia/process_wiki.py
@@ -340,15 +340,16 @@ def gen_autosuggestions(
     words_to_ignore = []
     if isinstance(ignore_words, str):
         words_to_ignore = [ignore_words]
+
     elif ignore_words is None:
         words_to_ignore = []
 
     print("Querying profanities to remove from suggestions.")
-    query_path = (
+    profanity_query_path = (
         Path(__file__).parent.resolve() / ".." / "wikidata" / "query_profanity.sparql"
     )
     # First format the lines into a multi-line string and then pass this to SPARQLWrapper.
-    with open(query_path, encoding="utf-8") as file:
+    with open(profanity_query_path, encoding="utf-8") as file:
         query_lines = file.readlines()
 
     query = "".join(query_lines).replace(
@@ -380,7 +381,7 @@ def gen_autosuggestions(
             f"Queried {len(profanities)} words to be removed from autosuggest options."
         )
 
-    # Precompute bigram frequencies
+    # Precompute bigram frequencies.
     print("Precomputing word relationships (bigrams)...")
     bigram_counter = defaultdict(Counter)
     for text in tqdm(
@@ -389,7 +390,7 @@ def gen_autosuggestions(
         for w1, w2 in zip(text, text[1:]):
             bigram_counter[w1][w2] += 1
 
-    # Build autosuggestions
+    # Build autosuggestions.
     autosuggest_dict = {}
     for w in tqdm(
         top_words, desc="Autosuggestions generated", unit="word", disable=not verbose
@@ -406,7 +407,7 @@ def gen_autosuggestions(
                 and next_word != next_word.upper()  # no upper case suggestions
                 and not next_word.lower().startswith(
                     ("nazi", "наци")
-                )  # Lots of detailed articles on WWII on wikipedia
+                )  # lots of detailed articles on WWII on wikipedia
             ):
                 autosuggestions.append(next_word)
 


### PR DESCRIPTION


<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also, please describe shortly how you tested that your change actually works.
-->

This PR proposes an optimization to how autosuggestions are generated.

Instead of iterating through all articles multiple times (once for each top word), this version processes the corpus only once to build a word → next-word frequency map (bigrams).

This reduces the generation time for 500 top words across ~700k articles from tens of hours to around 2 hours, while producing nearly identical results.

I compared the top 10 autosuggestions generated by both methods, and the outputs were similar.

### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- Feel free to delete this section if this does not apply. -->

- #ISSUE_NUMBER
