### PR TITLE
Bug: Enhance sqlite conversion and tests

### DIFF
--- a/src/scribe_data/cli/convert.py
+++ b/src/scribe_data/cli/convert.py
@@ -12,7 +12,9 @@ from scribe_data.load.data_to_sqlite import data_to_sqlite
 from scribe_data.utils import (
     DEFAULT_CSV_EXPORT_DIR,
     DEFAULT_JSON_EXPORT_DIR,
+    DEFAULT_SQLITE_EXPORT_DIR,
     DEFAULT_TSV_EXPORT_DIR,
+    DEFAULT_WIKTIONARY_JSON_EXPORT_DIR,
     camel_to_snake,
     check_index_exists,
 )
@@ -412,6 +414,25 @@ def convert_wrapper(
         This function does not return any value; it performs a conversion operation.
     """
     # Route the function call to the correct conversion function.
+    if output_dir is None:
+        output_dir = {
+            "json": DEFAULT_JSON_EXPORT_DIR,
+            "csv": DEFAULT_CSV_EXPORT_DIR,
+            "tsv": DEFAULT_TSV_EXPORT_DIR,
+            "sqlite": DEFAULT_SQLITE_EXPORT_DIR,
+        }.get(output_type, DEFAULT_JSON_EXPORT_DIR)
+
+    if input_path is None and data_types:
+        is_wiktionary = any(
+            isinstance(dt, str) and dt.startswith("wiktionary")
+            for dt in (data_types if isinstance(data_types, list) else [data_types])
+        )
+        input_path = (
+            DEFAULT_WIKTIONARY_JSON_EXPORT_DIR
+            if is_wiktionary
+            else DEFAULT_JSON_EXPORT_DIR
+        )
+
     if output_type == "json" and languages and data_types:
         convert_to_json(
             language=languages[0],  # only one language possible

--- a/src/scribe_data/cli/main.py
+++ b/src/scribe_data/cli/main.py
@@ -270,6 +270,7 @@ def main() -> None:
         "--input-file",
         type=Path,
         required=False,
+        default=None,
         help="The path to the input file to convert.",
     )
     convert_parser.add_argument(
@@ -284,6 +285,7 @@ def main() -> None:
         "-od",
         "--output-dir",
         type=str,
+        default=None,
         help="The directory where the output file will be saved.",
     )
     convert_parser.add_argument(

--- a/src/scribe_data/load/data_to_sqlite.py
+++ b/src/scribe_data/load/data_to_sqlite.py
@@ -233,6 +233,10 @@ def wiktionary_translations_to_sqlite(
 
         print(f"Creating/Updating {language} {table_name} table...")
 
+        if json_path.stat().st_size == 0:
+            print(f"Warning: {json_path.name} is empty. Skipping.")
+            continue
+
         with open(json_path, "r", encoding="utf-8") as f:
             json_data = json.load(f)
 

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -434,6 +434,55 @@ class TestConvert(unittest.TestCase):
             overwrite=True,
         )
 
+    @patch("scribe_data.cli.convert.data_to_sqlite", autospec=True)
+    def test_convert_wrapper_german_wiktionary_translations_sqlite(
+        self, mock_data_to_sqlite: MagicMock
+    ) -> None:
+        convert_wrapper(
+            languages=["german"],
+            data_types=["wiktionary_translations"],
+            input_path=Path("/input"),
+            output_dir=Path("/output"),
+            output_type="sqlite",
+            overwrite=False,
+            identifier_case="camel",
+        )
+
+        mock_data_to_sqlite.assert_called_once_with(
+            languages=["german"],
+            specific_tables=["wiktionary_translations"],
+            identifier_case="camel",
+            input_file=Path("/input"),
+            output_file=Path("/output"),
+            overwrite=False,
+        )
+
+    @patch(
+        "scribe_data.cli.convert.DEFAULT_WIKTIONARY_JSON_EXPORT_DIR",
+        new=Path("/mock_wiktionary_dir"),
+    )
+    @patch("scribe_data.cli.convert.data_to_sqlite", autospec=True)
+    def test_convert_wrapper_wiktionary_no_input_path_uses_wiktionary_default(
+        self, mock_data_to_sqlite: MagicMock
+    ) -> None:
+        convert_wrapper(
+            languages=["german"],
+            data_types=["wiktionary_translations"],
+            input_path=None,
+            output_dir=Path("/output"),
+            output_type="sqlite",
+            overwrite=False,
+        )
+
+        mock_data_to_sqlite.assert_called_once_with(
+            languages=["german"],
+            specific_tables=["wiktionary_translations"],
+            identifier_case="camel",
+            input_file=Path("/mock_wiktionary_dir"),
+            output_file=Path("/output"),
+            overwrite=False,
+        )
+
     def test_convert(self) -> None:
         with self.assertRaises(ValueError) as context:
             convert_wrapper(

--- a/tests/cli/test_convert.py
+++ b/tests/cli/test_convert.py
@@ -430,7 +430,7 @@ class TestConvert(unittest.TestCase):
             specific_tables=["nouns"],
             identifier_case="camel",
             input_file=Path(mock_input_file),
-            output_file=None,
+            output_file=Path("scribe_data_sqlite_export"),
             overwrite=True,
         )
 


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [X] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

Added default output directory handling in `convert_wrapper` based on output type and implemented logic to set input path to default Wiktionary JSON export directory if no input path is provided and data types include 'wiktionary'.
  
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
-->

### Related issue

<!--- Scribe-Data prefers that pull requests be related to already open issues. -->
<!--- If applicable, please link to the issue by replacing ISSUE_NUMBER with the appropriate number below. -->
<!--- You can also put "Closes" before the # to close the issue on merge, or say there is no related issue. -->

- there is no related issue.
