### PR TITLE
Add Complexipy for complexity checks in CI

### DIFF
--- a/.github/workflows/ci_static_analysis.yaml
+++ b/.github/workflows/ci_static_analysis.yaml
@@ -64,3 +64,7 @@ jobs:
       - name: Run numpydoc Documentation Check
         if: always()
         run: uv run numpydoc lint ./src/**/*.py
+
+      - name: Run complexipy - Complexity Check
+        if: always()
+        run: uv run complexipy .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "complexipy",
     "prek>=0.4.1",
     "pytest>=9.0.3",
     "pytest-cov>=7.1.0",


### PR DESCRIPTION
Closes #672

Adds complexipy to pyproject.toml dev dependencies and includes it in the ci_static_analysis.yaml workflow to enforce maintainability standards as requested.