### PR TITLE
ty error fixes

### DIFF
--- a/src/scribe_data/check/check_missing_forms/split_query.py
+++ b/src/scribe_data/check/check_missing_forms/split_query.py
@@ -37,7 +37,7 @@ def split_group_by_identifier(
     for lang, data in language_entry.items():
         for data_type, missing_features_list in data.items():
             # Group features by their first identifier.
-            identifier_groups = defaultdict(list)
+            identifier_groups: defaultdict[str, list] = defaultdict(list)
 
             # First try to group by the first identifier in each feature list.
             for feature_list in missing_features_list:
@@ -47,7 +47,7 @@ def split_group_by_identifier(
                     identifier_groups[key].append(feature_list)
 
             # Now check if any groups have more than 6 features.
-            final_groups = []
+            final_groups: list[list] = []
 
             for features in identifier_groups.values():
                 if len(features) <= 6:
@@ -56,7 +56,7 @@ def split_group_by_identifier(
 
                 else:
                     # This group is too large so it needs to split further by the second identifier.
-                    second_level_groups = defaultdict(list)
+                    second_level_groups: defaultdict[str, list] = defaultdict(list)
 
                     for feature_list in features:
                         if len(feature_list) > 1:
@@ -78,8 +78,8 @@ def split_group_by_identifier(
                             final_groups.append(chunk)
 
             # Now combine small groups if possible to reduce query files.
-            optimized_groups = []
-            current_group = []
+            optimized_groups: list[list] = []
+            current_group: list = []
 
             # Sort groups by size to try combining smaller ones first.
             final_groups.sort(key=len)

--- a/src/scribe_data/check/check_project_metadata.py
+++ b/src/scribe_data/check/check_project_metadata.py
@@ -19,7 +19,7 @@ from scribe_data.utils import (
 all_data_types = tuple(data_type_metadata.keys())
 
 
-def get_available_languages() -> dict[str, list[str]]:
+def get_available_languages() -> dict[str, dict[str, list[str]]]:
     """
     Get available languages from the data extraction folder.
 

--- a/src/scribe_data/cli/convert.py
+++ b/src/scribe_data/cli/convert.py
@@ -66,6 +66,9 @@ def convert_to_json(
 
     data_types = [data_types] if isinstance(data_types, str) else data_types
 
+    if not data_types:
+        return
+
     if output_dir is None:
         output_dir = DEFAULT_JSON_EXPORT_DIR
 
@@ -96,7 +99,7 @@ def convert_to_json(
                 # Use the first row to inspect column headers.
                 first_row = rows[0]
                 keys = list(first_row.keys())
-                data = {}
+                data: dict = {}
 
                 if len(keys) == 1:
                     # Handle Case: { key: None }.
@@ -135,10 +138,10 @@ def convert_to_json(
 
                             entry = {"emoji": emoji, "is_base": is_base, "rank": rank}
 
-                            if key not in data:
-                                data[key] = []
+                            if key is None:
+                                continue
 
-                            data[key].append(entry)
+                            data.setdefault(key, []).append(entry)
 
                     else:
                         # Handle Case: { key: { value1: ..., value2: ... } }.

--- a/src/scribe_data/utils.py
+++ b/src/scribe_data/utils.py
@@ -571,7 +571,7 @@ def camel_to_snake(name: str) -> str:
 # MARK: Check Dump
 
 
-def check_lexeme_dump_prompt_download(output_dir: Path) -> Optional[bool | Path]:
+def check_lexeme_dump_prompt_download(output_dir: Path) -> bool | Path | None:
     """
     Check to see if a Wikidata lexeme dump exists and prompts the user to download one if not.
 

--- a/src/scribe_data/wikidata/wikidata_utils.py
+++ b/src/scribe_data/wikidata/wikidata_utils.py
@@ -22,9 +22,9 @@ sparql.setMethod(POST)
 
 
 def parse_wd_lexeme_dump(
-    languages: str | None,
+    languages: str | list[str] | None,
     data_types: list[str] | None = None,
-    wikidata_dump_type: str | None = [""],
+    wikidata_dump_type: str | list[str] | None = None,
     output_dir: Path | None = DEFAULT_WIKIDATA_DUMP_EXPORT_DIR,
     wikidata_dump_path: Path | None = DEFAULT_WIKIDATA_DUMP_EXPORT_DIR,
     overwrite_all: bool = False,
@@ -86,7 +86,8 @@ def parse_wd_lexeme_dump(
             )
 
         else:
-            print(f"Language to process: {languages.capitalize()}")
+            if isinstance(languages, str):
+                print(f"Language to process: {languages.capitalize()}")
 
         print(
             f"Data types to process: {', '.join([d.capitalize() for d in data_types or []])}"
@@ -104,12 +105,21 @@ def parse_wd_lexeme_dump(
                 "[bold green]We'll use the following lexeme dump[/bold green]",
                 file_path,
             )
+            normalized_languages = languages or ""
+            if isinstance(wikidata_dump_type, str):
+                normalized_dump_type = [wikidata_dump_type]
+            elif wikidata_dump_type is None:
+                normalized_dump_type = []
+            else:
+                normalized_dump_type = wikidata_dump_type
+
             parse_dump(
-                languages=languages,
-                parse_type=wikidata_dump_type,
+                languages=normalized_languages,
+                parse_type=normalized_dump_type,
                 data_types=data_types,
                 file_path=file_path,
                 output_dir=output_dir,
                 overwrite_all=overwrite_all,
             )
-            return
+
+        return

--- a/src/scribe_data/wiktionary/parse_translations.py
+++ b/src/scribe_data/wiktionary/parse_translations.py
@@ -1163,7 +1163,7 @@ def parse_xml_dump(
 
 def parse_wiktionary_translations(
     target_languages: str | list[str] | None = None,
-    wiktionary_dump_path: str | Path = None,
+    wiktionary_dump_path: str | Path | None = None,
     output_dir: Path | None = DEFAULT_WIKTIONARY_JSON_EXPORT_DIR,
     overwrite: bool = False,
 ) -> None:


### PR DESCRIPTION
### Contributor checklist
- [x] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [x] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

### Description

Fixes all `ty` type checker errors caught in the CI pipeline, across multiple files including
- **`src/scribe_data/check/check_missing_forms/split_query.py`**
- **`src/scribe_data/check/check_project_metadata.py`**
- **`src/scribe_data/cli/convert.py`**
- **`src/scribe_data/cli/get.py`**
- **`src/scribe_data/wikidata/wikidata_utils.py`**
- **`src/scribe_data/wiktionary/parse_translations.py`**
- **`src/scribe_data/utils.py`**

### Testing
<img width="649" height="63" alt="image" src="https://github.com/user-attachments/assets/5a626ca7-2500-4fa1-8e05-5ae923cd7413" />

### Related issue

- Closes #695 