### PR TITLE
Add `User-Agent` header for Wikimedia requests in download scripts

### DIFF
--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -1,6 +1,6 @@
 [
   {
-    "path": "Scribe-Data/src/scribe_data/check/check_missing_forms/check_missing_forms.py",
+    "path": "scribe_data/check/check_missing_forms/check_missing_forms.py",
     "file_name": "check_missing_forms.py",
     "functions": [
       {
@@ -26,7 +26,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/check/check_missing_forms/generate_query.py",
+    "path": "scribe_data/check/check_missing_forms/generate_query.py",
     "file_name": "generate_query.py",
     "functions": [
       {
@@ -36,7 +36,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/check/check_missing_forms/pr_body.py",
+    "path": "scribe_data/check/check_missing_forms/pr_body.py",
     "file_name": "pr_body.py",
     "functions": [
       {
@@ -46,7 +46,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/check/check_missing_forms/split_query.py",
+    "path": "scribe_data/check/check_missing_forms/split_query.py",
     "file_name": "split_query.py",
     "functions": [
       {
@@ -56,7 +56,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/check/check_project_metadata.py",
+    "path": "scribe_data/check/check_project_metadata.py",
     "file_name": "check_project_metadata.py",
     "functions": [
       {
@@ -78,7 +78,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/check/check_project_structure.py",
+    "path": "scribe_data/check/check_project_structure.py",
     "file_name": "check_project_structure.py",
     "functions": [
       {
@@ -92,7 +92,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/check/check_pyicu.py",
+    "path": "scribe_data/check/check_pyicu.py",
     "file_name": "check_pyicu.py",
     "functions": [
       {
@@ -102,7 +102,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/check/check_query_forms.py",
+    "path": "scribe_data/check/check_query_forms.py",
     "file_name": "check_query_forms.py",
     "functions": [
       {
@@ -128,7 +128,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/check/check_query_identifiers.py",
+    "path": "scribe_data/check/check_query_identifiers.py",
     "file_name": "check_query_identifiers.py",
     "functions": [
       {
@@ -138,7 +138,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/cli/cli_utils.py",
+    "path": "scribe_data/cli/cli_utils.py",
     "file_name": "cli_utils.py",
     "functions": [
       {
@@ -152,7 +152,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/cli/contracts/check.py",
+    "path": "scribe_data/cli/contracts/check.py",
     "file_name": "check.py",
     "functions": [
       {
@@ -162,7 +162,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/cli/contracts/filter.py",
+    "path": "scribe_data/cli/contracts/filter.py",
     "file_name": "filter.py",
     "functions": [
       {
@@ -176,7 +176,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/cli/convert/to_csv_or_tsv.py",
+    "path": "scribe_data/cli/convert/to_csv_or_tsv.py",
     "file_name": "to_csv_or_tsv.py",
     "functions": [
       {
@@ -186,7 +186,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/cli/convert/to_json.py",
+    "path": "scribe_data/cli/convert/to_json.py",
     "file_name": "to_json.py",
     "functions": [
       {
@@ -196,7 +196,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/cli/convert/to_sqlite.py",
+    "path": "scribe_data/cli/convert/to_sqlite.py",
     "file_name": "to_sqlite.py",
     "functions": [
       {
@@ -214,7 +214,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/cli/convert/wrapper.py",
+    "path": "scribe_data/cli/convert/wrapper.py",
     "file_name": "wrapper.py",
     "functions": [
       {
@@ -224,7 +224,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/cli/download/wikidata_lexeme_dump.py",
+    "path": "scribe_data/cli/download/wikidata_lexeme_dump.py",
     "file_name": "wikidata_lexeme_dump.py",
     "functions": [
       {
@@ -242,7 +242,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/cli/download/wiktionary_dump.py",
+    "path": "scribe_data/cli/download/wiktionary_dump.py",
     "file_name": "wiktionary_dump.py",
     "functions": [
       {
@@ -252,7 +252,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/cli/get.py",
+    "path": "scribe_data/cli/get.py",
     "file_name": "get.py",
     "functions": [
       {
@@ -262,7 +262,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/cli/interactive/run.py",
+    "path": "scribe_data/cli/interactive/run.py",
     "file_name": "run.py",
     "functions": [
       {
@@ -272,7 +272,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/cli/list/data_types.py",
+    "path": "scribe_data/cli/list/data_types.py",
     "file_name": "data_types.py",
     "functions": [
       {
@@ -282,7 +282,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/cli/main.py",
+    "path": "scribe_data/cli/main.py",
     "file_name": "main.py",
     "functions": [
       {
@@ -292,7 +292,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/cli/total/print_values.py",
+    "path": "scribe_data/cli/total/print_values.py",
     "file_name": "print_values.py",
     "functions": [
       {
@@ -306,7 +306,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/cli/total/query.py",
+    "path": "scribe_data/cli/total/query.py",
     "file_name": "query.py",
     "functions": [
       {
@@ -316,7 +316,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/cli/total/wrapper.py",
+    "path": "scribe_data/cli/total/wrapper.py",
     "file_name": "wrapper.py",
     "functions": [
       {
@@ -326,7 +326,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/unicode/process_unicode.py",
+    "path": "scribe_data/unicode/process_unicode.py",
     "file_name": "process_unicode.py",
     "functions": [
       {
@@ -336,7 +336,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/utils.py",
+    "path": "scribe_data/utils.py",
     "file_name": "utils.py",
     "functions": [
       {
@@ -350,7 +350,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/wikidata/format_data.py",
+    "path": "scribe_data/wikidata/format_data.py",
     "file_name": "format_data.py",
     "functions": [
       {
@@ -360,7 +360,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/wikidata/parse_dump.py",
+    "path": "scribe_data/wikidata/parse_dump.py",
     "file_name": "parse_dump.py",
     "functions": [
       {
@@ -390,7 +390,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/wikidata/query_data.py",
+    "path": "scribe_data/wikidata/query_data.py",
     "file_name": "query_data.py",
     "functions": [
       {
@@ -400,7 +400,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/wikidata/wikidata_utils.py",
+    "path": "scribe_data/wikidata/wikidata_utils.py",
     "file_name": "wikidata_utils.py",
     "functions": [
       {
@@ -410,7 +410,7 @@
     ]
   },
   {
-    "path": "Scribe-Data/src/scribe_data/wiktionary/parse_translations.py",
+    "path": "scribe_data/wiktionary/parse_translations.py",
     "file_name": "parse_translations.py",
     "functions": [
       {
@@ -448,16 +448,6 @@
       {
         "name": "_parse_ast_u_tabelle",
         "complexity": 51
-      }
-    ]
-  },
-  {
-    "path": "Scribe-Data/tests/wikidata/test_wikidata_check_query.py",
-    "file_name": "test_wikidata_check_query.py",
-    "functions": [
-      {
-        "name": "validate_forms",
-        "complexity": 20
       }
     ]
   }

--- a/docs/source/scribe_data/cli/index.rst
+++ b/docs/source/scribe_data/cli/index.rst
@@ -387,34 +387,49 @@ Download Command
 ~~~~~~~~~~~~~~~~
 
 Download Wikidata lexeme dumps or Wiktionary dumps for offline data extraction.
+Pass ``-wdp`` for a Wikidata dump or ``-wtp`` for a Wiktionary dump.
 
 Usage
 ^^^^^
 
 .. code-block:: bash
 
-    scribe-data download
+    scribe-data download [arguments]
 
 Options
 ^^^^^^^
 
-- ``--wiktionary-dump``: Download a Wiktionary dump instead of a Wikidata lexeme dump.
-- ``-lang, --language LANGUAGE``: The language edition of Wiktionary to download (e.g. ``de`` for German Wiktionary). Defaults to English Wiktionary (``enwiktionary``) when omitted.
+- ``-wdp, --wikidata-dump-path [PATH]``: Download a Wikidata lexeme dump. Uses ``./scribe_data_wikidata_dumps_export`` if no path is provided.
+- ``-wtp, --wiktionary-dump-path [PATH]``: Download a Wiktionary dump. Uses ``./scribe_data_wiktionary_dumps_export`` if no path is provided.
+- ``-ds, --dump-snapshot [SNAPSHOT]``: The dump snapshot to download. For Wikidata use ``latest-lexemes`` or a date in ``YYYYMMDD`` format. For Wiktionary defaults to ``latest``.
+- ``-lang, --language LANGUAGE``: The language or ISO code for Wiktionary dumps (e.g. ``de`` for German Wiktionary). Defaults to English (``en``) when omitted.
 
 Examples
 ^^^^^^^^
+
+Download the latest Wikidata lexeme dump:
+
+.. code-block:: bash
+
+    scribe-data download -wdp --dump-snapshot latest-lexemes
+
+Download a Wikidata lexeme dump for a specific date:
+
+.. code-block:: bash
+
+    scribe-data download -wdp --dump-snapshot 20240101
 
 Download the English Wiktionary dump:
 
 .. code-block:: bash
 
-    scribe-data download --wiktionary-dump
+    scribe-data download -wtp
 
 Download a specific language's Wiktionary dump:
 
 .. code-block:: bash
 
-    scribe-data download --wiktionary-dump --language de
+    scribe-data download -wtp --language de
 
 Behavior and Output
 ^^^^^^^^^^^^^^^^^^^
@@ -444,8 +459,8 @@ Behavior and Output
 
     .. code-block:: text
 
-        Downloading dump to scribe_data_wikidata_dumps_export\latest-lexemes.json.bz2...
-        scribe_data_wikidata_dumps_export\latest-lexemes.json.bz2: 100%|███████████████████| 370M/370M [04:20<00:00, 1.42MiB/s]
+        Downloading dump to scribe_data_wikidata_dumps_export/latest-lexemes.json.bz2...
+        scribe_data_wikidata_dumps_export/latest-lexemes.json.bz2: 100%|███████████████████| 370M/370M [04:20<00:00, 1.42MiB/s]
         Wikidata lexeme dump download completed successfully!
 
 

--- a/src/scribe_data/cli/download/wikidata_lexeme_dump.py
+++ b/src/scribe_data/cli/download/wikidata_lexeme_dump.py
@@ -18,6 +18,7 @@ from tqdm import tqdm
 from scribe_data.utils import (
     DEFAULT_WIKIDATA_DUMP_EXPORT_DIR,
     DEFAULT_WIKTIONARY_DUMP_EXPORT_DIR,
+    WMF_HEADERS,
     check_lexeme_dump_prompt_download,
 )
 
@@ -145,7 +146,7 @@ def download_wd_lexeme_dump(
             If the dump file does not exist.
         """
         entity_url = f"{base_url}/{target_entity}/"
-        entity_response = requests.get(entity_url, timeout=30)
+        entity_response = requests.get(entity_url, headers=WMF_HEADERS, timeout=30)
         entity_response.raise_for_status()
         dump_filenames = re.findall(r'href="([^"]+)"', entity_response.text)
 
@@ -167,7 +168,7 @@ def download_wd_lexeme_dump(
             )
             print("We could not find your requested Wikidata lexeme dump.")
 
-            response = requests.get(base_url, timeout=30)
+            response = requests.get(base_url, headers=WMF_HEADERS, timeout=30)
             other_old_dumps = re.findall(r'href="([^"]+)/"', response.text)
 
             user_response = questionary.confirm(
@@ -193,7 +194,7 @@ def download_wd_lexeme_dump(
                         return
 
     try:
-        response = requests.get(base_url, timeout=30)
+        response = requests.get(base_url, headers=WMF_HEADERS, timeout=30)
         response.raise_for_status()
         latest_dump = re.findall(r'href="([^"]+)"', response.text)
         if "latest-all.json.bz2" in latest_dump:
@@ -267,12 +268,14 @@ def wd_lexeme_dump_download_wrapper(
         if user_response:
             rprint(f"[bold blue]Downloading dump to {output_path}...[/bold blue]")
 
-            response = requests.get(dump_url, stream=True, timeout=30)
+            response = requests.get(
+                dump_url, headers=WMF_HEADERS, stream=True, timeout=30
+            )
             total_size = int(response.headers.get("content-length", 0))
 
             with open(output_path, "wb") as f:
                 with tqdm(
-                    total=total_size, unit="iB", unit_scale=True, desc=output_path
+                    total=total_size, unit="iB", unit_scale=True, desc=filename
                 ) as pbar:
                     for chunk in response.iter_content(chunk_size=8192):
                         if chunk:

--- a/src/scribe_data/cli/download/wiktionary_dump.py
+++ b/src/scribe_data/cli/download/wiktionary_dump.py
@@ -12,6 +12,7 @@ from tqdm import tqdm
 
 from scribe_data.utils import (
     DEFAULT_WIKTIONARY_DUMP_EXPORT_DIR,
+    WMF_HEADERS,
     resolve_lang_iso,
 )
 
@@ -74,7 +75,7 @@ def download_wiktionary_dumps(
 
         rprint(f"[bold blue]Checking dump validity at {download_url}...[/bold blue]")
         try:
-            response = requests.head(download_url, timeout=30)
+            response = requests.head(download_url, headers=WMF_HEADERS, timeout=30)
             response.raise_for_status()
 
         except requests.exceptions.RequestException as e:
@@ -98,7 +99,9 @@ def download_wiktionary_dumps(
 
         rprint(f"[bold blue]Downloading to {output_path}...[/bold blue]")
         try:
-            response = requests.get(download_url, stream=True, timeout=30)
+            response = requests.get(
+                download_url, headers=WMF_HEADERS, stream=True, timeout=30
+            )
             response.raise_for_status()
             total_size = int(response.headers.get("content-length", 0))
 

--- a/src/scribe_data/utils.py
+++ b/src/scribe_data/utils.py
@@ -8,7 +8,7 @@ import json
 import os
 import re
 from datetime import datetime
-from importlib import resources
+from importlib import metadata, resources
 from pathlib import Path
 from typing import Any
 
@@ -34,6 +34,9 @@ DEFAULT_WIKTIONARY_DUMP_EXPORT_DIR = Path("scribe_data_wiktionary_dumps_export")
 
 DEFAULT_CONTRACTS_EXPORT_DIR = Path("scribe_data_contracts")
 DEFAULT_DATA_CONTRACTS_DIR = Path(__file__).parent / "resources" / "data_contracts"
+
+project_homepage = metadata.metadata("scribe-data").get("Home-page")
+WMF_HEADERS = {"User-Agent": f"{PROJECT_ROOT} ({project_homepage})"}
 
 WIKIDATA_QUERIES_ALL_DATA_DIR = Path(__file__).parent / "wikidata" / "queries_all_data"
 WIKIDATA_QUERIES_SCRIBE_APPS_DIR = (

--- a/tests/cli/download/test_cli_download_wikidata_lexeme_dump.py
+++ b/tests/cli/download/test_cli_download_wikidata_lexeme_dump.py
@@ -16,7 +16,7 @@ from scribe_data.cli.download.wikidata_lexeme_dump import (
     parse_date,
     wd_lexeme_dump_download_wrapper,
 )
-from scribe_data.utils import check_lexeme_dump_prompt_download
+from scribe_data.utils import WMF_HEADERS, check_lexeme_dump_prompt_download
 
 
 class TestDownloadCLI(unittest.TestCase):
@@ -70,6 +70,11 @@ class TestDownloadCLI(unittest.TestCase):
         self.assertEqual(
             url,
             "https://dumps.wikimedia.org/wikidatawiki/entities/latest-lexemes.json.bz2",
+        )
+        mock_get.assert_called_with(
+            "https://dumps.wikimedia.org/wikidatawiki/entities",
+            headers=WMF_HEADERS,
+            timeout=30,
         )
 
     @patch("scribe_data.cli.download.wikidata_lexeme_dump.requests.get")
@@ -129,6 +134,16 @@ class TestDownloadCLI(unittest.TestCase):
             self.assertIn("latest-lexemes.json.bz2", str(download_path))
             mock_makedirs.assert_called_with(Path("test_export_dir"), exist_ok=True)
             mock_confirm.assert_called_once()
+
+            # tqdm desc must be str; PosixPath is not subscriptable and breaks the bar.
+            mock_tqdm.assert_called()
+            tqdm_kwargs = mock_tqdm.call_args.kwargs
+            self.assertEqual(tqdm_kwargs["desc"], "latest-lexemes.json.bz2")
+            self.assertIsInstance(tqdm_kwargs["desc"], str)
+
+            # Wikimedia dumps require a User-Agent header.
+            for call in mock_get.call_args_list:
+                self.assertEqual(call.kwargs.get("headers"), WMF_HEADERS)
 
     @patch("scribe_data.utils.questionary.select")
     @patch(


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [X] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

- Introduced [WMF_HEADERS](https://www.mediawiki.org/wiki/Template:WMF_Section_header) to set a User-Agent for requests in wikidata_lexeme_dump.py and wiktionary_dump.py.
- Updated request calls to include the User-Agent header for better compliance with Wikimedia's API requirements.
- Enhanced tests to verify the inclusion of the User-Agent header in requests.
<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
-->

 