### PR TITLE
fix: coerce dump paths to Path and mkdir before JSON export

### DIFF
--- a/src/scribe_data/cli/download/wikidata_lexeme_dump.py
+++ b/src/scribe_data/cli/download/wikidata_lexeme_dump.py
@@ -234,7 +234,7 @@ def wd_lexeme_dump_download_wrapper(
         - Returns None if the user chooses not to proceed with the download or no valid dump URL is found.
     """
     try:
-        output_dir = output_dir or DEFAULT_WIKIDATA_DUMP_EXPORT_DIR
+        output_dir = Path(output_dir or DEFAULT_WIKIDATA_DUMP_EXPORT_DIR)
 
         os.makedirs(output_dir, exist_ok=True)
 

--- a/src/scribe_data/cli/download/wiktionary_dump.py
+++ b/src/scribe_data/cli/download/wiktionary_dump.py
@@ -66,7 +66,8 @@ def download_wiktionary_dumps(
     wiktionaries = [f"{iso}wiktionary" for iso in language_isos]
     wiktionary_urls = [f"https://dumps.wikimedia.org/{w}" for w in wiktionaries]
 
-    Path(output_dir).mkdir(parents=True, exist_ok=True)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
     for i, w, u in zip(language_isos, wiktionaries, wiktionary_urls):
         # Note: Remove the snapshot from the resulting filename so Scribe-Server always looks for one file.
         filename = f"{w}-pages-articles.xml.bz2"

--- a/src/scribe_data/unicode/generate_emoji_keywords.py
+++ b/src/scribe_data/unicode/generate_emoji_keywords.py
@@ -56,14 +56,6 @@ def generate_emoji(language: str, output_dir: Path = Path("")) -> None:
             )
             return
 
-        updated_path = (
-            Path(str(output_dir)[2:])
-            if str(output_dir).startswith("./")
-            else output_dir
-        )
-        export_dir = Path(updated_path) / language.capitalize()
-        export_dir.mkdir(parents=True, exist_ok=True)
-
         if emoji_keywords_dict := gen_emoji_lexicon(
             language=language,
             emojis_per_keyword=EMOJI_KEYWORDS_DICT,

--- a/src/scribe_data/utils.py
+++ b/src/scribe_data/utils.py
@@ -405,6 +405,7 @@ def export_formatted_data(
         / language.lower().replace(" ", "_")
         / f"{data_type.replace('-', '_')}.json"
     )
+    export_path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(export_path, "w", encoding="utf-8") as file:
         json.dump(formatted_data, file, ensure_ascii=False, indent=0)

--- a/tests/cli/download/test_cli_download_wikidata_lexeme_dump.py
+++ b/tests/cli/download/test_cli_download_wikidata_lexeme_dump.py
@@ -145,6 +145,45 @@ class TestDownloadCLI(unittest.TestCase):
             for call in mock_get.call_args_list:
                 self.assertEqual(call.kwargs.get("headers"), WMF_HEADERS)
 
+    @patch("scribe_data.cli.download.wikidata_lexeme_dump.requests.get")
+    @patch(
+        "scribe_data.cli.download.wikidata_lexeme_dump.check_lexeme_dump_prompt_download",
+        return_value=False,
+    )
+    @patch("scribe_data.cli.download.wikidata_lexeme_dump.open", new_callable=mock_open)
+    @patch("scribe_data.cli.download.wikidata_lexeme_dump.tqdm")
+    @patch("scribe_data.cli.download.wikidata_lexeme_dump.os.makedirs")
+    @patch("scribe_data.cli.download.wikidata_lexeme_dump.questionary.confirm")
+    def test_wd_lexeme_dump_download_wrapper_accepts_str_output_dir(
+        self,
+        mock_confirm: MagicMock,
+        mock_makedirs: MagicMock,
+        mock_tqdm: MagicMock,
+        mock_file: MagicMock,
+        mock_check_prompt: MagicMock,
+        mock_get: MagicMock,
+    ) -> None:
+        """
+        CLI passes -wdp as str; Path join must not raise TypeError.
+        """
+        mock_confirm.return_value.ask.return_value = True
+        mock_get.return_value.text = 'href="latest-all.json.bz2"'
+        mock_get.return_value.raise_for_status = MagicMock()
+        mock_get.return_value.headers = {"content-length": "100"}
+        mock_get.return_value.iter_content = lambda chunk_size: [b"data"] * 10
+
+        download_path = wd_lexeme_dump_download_wrapper(
+            output_dir="./scribe_data_wikidata_dumps_export"
+        )
+        self.assertIsNotNone(download_path)
+        self.assertEqual(
+            download_path,
+            Path("scribe_data_wikidata_dumps_export") / "latest-lexemes.json.bz2",
+        )
+        mock_makedirs.assert_called_with(
+            Path("scribe_data_wikidata_dumps_export"), exist_ok=True
+        )
+
     @patch("scribe_data.utils.questionary.select")
     @patch(
         "scribe_data.utils.Path.glob",


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [X] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

- Ensure output directories are created as Path objects in download scripts and add directory creation in export_formatted_data function.

- Fixing [the action](https://github.com/scribe-org/Scribe-Server/actions/runs/29205829211/job/86684999492) for scribe-server

<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
-->
 