### PR TITLE
Parse multi-lang -wdp dumps in one pass and fix progress bars

### DIFF
--- a/.github/workflows/ci_static_analysis.yaml
+++ b/.github/workflows/ci_static_analysis.yaml
@@ -24,7 +24,6 @@ on:
 
 jobs:
   format_check:
-    if: github.repository == 'scribe-org/Scribe-Data'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci_static_analysis.yaml
+++ b/.github/workflows/ci_static_analysis.yaml
@@ -24,6 +24,7 @@ on:
 
 jobs:
   format_check:
+    if: github.repository == 'scribe-org/Scribe-Data'
     strategy:
       fail-fast: false
       matrix:

--- a/complexipy-snapshot.json
+++ b/complexipy-snapshot.json
@@ -287,7 +287,7 @@
     "functions": [
       {
         "name": "main",
-        "complexity": 103
+        "complexity": 110
       }
     ]
   },
@@ -369,7 +369,7 @@
       },
       {
         "name": "LexemeProcessor::process_file",
-        "complexity": 22
+        "complexity": 26
       },
       {
         "name": "LexemeProcessor::_build_iso_mapping",
@@ -435,11 +435,11 @@
       },
       {
         "name": "_iter_dump_pages",
-        "complexity": 44
+        "complexity": 48
       },
       {
         "name": "parse_xml_dump",
-        "complexity": 45
+        "complexity": 49
       },
       {
         "name": "_parse_block_translations",

--- a/src/scribe_data/cli/main.py
+++ b/src/scribe_data/cli/main.py
@@ -520,20 +520,36 @@ def main() -> None:
 
                 # Process each language-datatype combination.
                 if languages and data_types:
-                    for language in languages:
-                        for data_type in data_types:
-                            get_data(
-                                languages=[language],
-                                data_types=[data_type],
-                                output_type=args.output_type,
-                                output_dir=args.output_dir,
-                                outputs_per_entry=args.outputs_per_entry,
-                                overwrite=args.overwrite,
-                                all_bool=args.all,
-                                identifier_case=args.identifier_case,
-                                wikidata_dump_path=args.wikidata_dump_path,
-                                wiktionary_dump=args.wiktionary_dump_path,
-                            )
+                    # Dump parse already handles multi lang/type in one pass.
+                    if args.wikidata_dump_path is not None:
+                        get_data(
+                            languages=languages,
+                            data_types=data_types,
+                            output_type=args.output_type,
+                            output_dir=args.output_dir,
+                            outputs_per_entry=args.outputs_per_entry,
+                            overwrite=args.overwrite,
+                            all_bool=args.all,
+                            identifier_case=args.identifier_case,
+                            wikidata_dump_path=args.wikidata_dump_path,
+                            wiktionary_dump=args.wiktionary_dump_path,
+                        )
+
+                    else:
+                        for language in languages:
+                            for data_type in data_types:
+                                get_data(
+                                    languages=[language],
+                                    data_types=[data_type],
+                                    output_type=args.output_type,
+                                    output_dir=args.output_dir,
+                                    outputs_per_entry=args.outputs_per_entry,
+                                    overwrite=args.overwrite,
+                                    all_bool=args.all,
+                                    identifier_case=args.identifier_case,
+                                    wikidata_dump_path=args.wikidata_dump_path,
+                                    wiktionary_dump=args.wiktionary_dump_path,
+                                )
 
                 else:
                     # Handle case where only language or data_type is provided.

--- a/src/scribe_data/wikidata/parse_dump.py
+++ b/src/scribe_data/wikidata/parse_dump.py
@@ -394,33 +394,50 @@ class LexemeProcessor:
             The file is processed and a summary is printed.
         """
         try:
-            # Use context manager for better resource handling.
-            with bz2.open(file_path, "rt", encoding="utf-8") as bzfile:
-                # Skip header if present.
-                first_line = bzfile.readline()
-                if not first_line.strip().startswith("["):
-                    bzfile.seek(0)
+            # Progress by compressed bytes read
+            compressed_size = Path(file_path).stat().st_size
+            with open(file_path, "rb") as raw:
+                with bz2.open(raw, "rt", encoding="utf-8") as bzfile:
+                    # Skip header if present.
+                    first_line = bzfile.readline()
+                    if not first_line.strip().startswith("["):
+                        bzfile.seek(0)
 
-                # Process in larger batches for better performance.
-                batch = []
-                start_time = time.time()
-                total_entries = int(Path(file_path).stat().st_size / 263)
+                    # Process in larger batches for better performance.
+                    batch = []
+                    start_time = time.time()
+                    last_pos = raw.tell()
 
-                for line in tqdm(
-                    bzfile, total=total_entries, desc="Processing entries"
-                ):
-                    if line.strip() not in ["[", "]", ",", ""]:
-                        batch.append(line)
+                    with tqdm(
+                        total=compressed_size,
+                        unit="B",
+                        unit_scale=True,
+                        desc="Processing entries",
+                    ) as pbar:
+                        if last_pos:
+                            pbar.update(last_pos)
 
-                        if len(batch) >= batch_size:
-                            self._process_batch(batch)
-                            batch.clear()  # more efficient than creating new list
+                        for line in bzfile:
+                            if line.strip() not in ["[", "]", ",", ""]:
+                                batch.append(line)
 
-                        self.stats["processed_entries"] += 1
+                                if len(batch) >= batch_size:
+                                    self._process_batch(batch)
+                                    batch.clear()
 
-                # Process remaining items.
-                if batch:
-                    self._process_batch(batch)
+                                self.stats["processed_entries"] += 1
+
+                            pos = raw.tell()
+                            if pos > last_pos:
+                                pbar.update(pos - last_pos)
+                                last_pos = pos
+
+                        if pbar.n < pbar.total:
+                            pbar.update(pbar.total - pbar.n)
+
+                    # Process remaining items.
+                    if batch:
+                        self._process_batch(batch)
 
         except EOFError:
             rprint(

--- a/src/scribe_data/wikidata/parse_dump.py
+++ b/src/scribe_data/wikidata/parse_dump.py
@@ -394,7 +394,7 @@ class LexemeProcessor:
             The file is processed and a summary is printed.
         """
         try:
-            # Progress by compressed bytes read
+            # Progress by compressed bytes read.
             compressed_size = Path(file_path).stat().st_size
             with open(file_path, "rb") as raw:
                 with bz2.open(raw, "rt", encoding="utf-8") as bzfile:

--- a/src/scribe_data/wiktionary/parse_translations.py
+++ b/src/scribe_data/wiktionary/parse_translations.py
@@ -978,6 +978,9 @@ def _iter_dump_pages(wiktionary_dump_path: Path, pbar=None):
                     if diff > 0:
                         pbar_ref.update(diff)
 
+                    if pbar_ref.total is not None and pbar_ref.n < pbar_ref.total:
+                        pbar_ref.update(pbar_ref.total - pbar_ref.n)
+
                 except (OSError, ValueError):
                     pass
 
@@ -1128,6 +1131,8 @@ def parse_xml_dump(
             yield word, text, target_langs_frozenset, config
 
         if pbar:
+            if pbar.total is not None and pbar.n < pbar.total:
+                pbar.update(pbar.total - pbar.n)
             pbar.refresh()
             pbar.close()
 

--- a/tests/cli/test_cli_get.py
+++ b/tests/cli/test_cli_get.py
@@ -681,3 +681,79 @@ class TestGetData(unittest.TestCase):
             overwrite=False,
             interactive=False,
         )
+
+
+class TestGetCommandDumpBatching(unittest.TestCase):
+    """
+    Unit tests for CLI get routing when using a Wikidata dump path.
+    """
+
+    @patch("scribe_data.cli.main.get_data")
+    @patch("scribe_data.cli.main.validate_language_and_data_type")
+    def test_wdp_batches_languages_and_data_types(
+        self, mock_validate: MagicMock, mock_get_data: MagicMock
+    ) -> None:
+        """
+        -wdp should parse all languages/types in a single get_data call.
+        """
+        from scribe_data.cli.main import main
+
+        test_args = [
+            "main.py",
+            "get",
+            "-lang",
+            "english",
+            "french",
+            "-dt",
+            "nouns",
+            "verbs",
+            "-wdp",
+            "-o",
+        ]
+        with patch("sys.argv", test_args):
+            main()
+
+        mock_get_data.assert_called_once()
+        _, kwargs = mock_get_data.call_args
+        self.assertEqual(kwargs["languages"], ["english", "french"])
+        self.assertEqual(kwargs["data_types"], ["nouns", "verbs"])
+        self.assertIsNotNone(kwargs["wikidata_dump_path"])
+        self.assertTrue(kwargs["overwrite"])
+
+    @patch("scribe_data.cli.main.get_data")
+    @patch("scribe_data.cli.main.validate_language_and_data_type")
+    def test_query_path_still_loops_pairs(
+        self, mock_validate: MagicMock, mock_get_data: MagicMock
+    ) -> None:
+        """
+        Without -wdp, keep one SPARQL get_data call per language-datatype pair.
+        """
+        from scribe_data.cli.main import main
+
+        test_args = [
+            "main.py",
+            "get",
+            "-lang",
+            "english",
+            "french",
+            "-dt",
+            "nouns",
+            "verbs",
+        ]
+        with patch("sys.argv", test_args):
+            main()
+
+        self.assertEqual(mock_get_data.call_count, 4)
+        pairs = [
+            (call.kwargs["languages"], call.kwargs["data_types"])
+            for call in mock_get_data.call_args_list
+        ]
+        self.assertEqual(
+            pairs,
+            [
+                (["english"], ["nouns"]),
+                (["english"], ["verbs"]),
+                (["french"], ["nouns"]),
+                (["french"], ["verbs"]),
+            ],
+        )

--- a/tests/wikidata/test_wikidata_dump.py
+++ b/tests/wikidata/test_wikidata_dump.py
@@ -3,7 +3,7 @@
 Tests for the CLI dump functionality.
 """
 
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -71,23 +71,35 @@ def test_wikidata_lexeme_processor_initialization(
     assert "nouns" in lexeme_processor.data_types
 
 
-@patch("builtins.open", new_callable=mock_open, read_data=Sample_Lexeme_Line)
-@patch("bz2.open")
+@patch("scribe_data.wikidata.parse_dump.tqdm")
 def test_wikidata_process_file(
-    mock_bz2_open: MagicMock, mock_file: MagicMock, lexeme_processor: LexemeProcessor
+    mock_tqdm: MagicMock, lexeme_processor: LexemeProcessor, tmp_path
 ) -> None:
     """
-    Test processing a file with sample lexeme data.
+    Test processing a bz2 dump; progress total is compressed file size.
     """
-    mock_bz2_open.return_value.__enter__.return_value = mock_file()
+    import bz2
 
-    # Mock Path.stat() to return a size.
-    with patch("pathlib.Path.stat") as mock_stat:
-        mock_stat.return_value.st_size = 1000
-        lexeme_processor.process_file("test.json.bz2")
+    dump_path = tmp_path / "test.json.bz2"
+    with bz2.open(dump_path, "wt", encoding="utf-8") as f:
+        f.write("[\n")
+        f.write(Sample_Lexeme_Line.strip() + "\n")
+        f.write("]\n")
 
-    # Verify that stats were updated.
+    compressed_size = dump_path.stat().st_size
+    pbar = MagicMock()
+    pbar.n = 0
+    pbar.total = compressed_size
+    pbar.update.side_effect = lambda n=1: setattr(pbar, "n", pbar.n + n)
+    mock_tqdm.return_value.__enter__.return_value = pbar
+    mock_tqdm.return_value.__exit__.return_value = False
+
+    lexeme_processor.process_file(str(dump_path))
+
     assert lexeme_processor.stats["processed_entries"] > 0
+    mock_tqdm.assert_called_once()
+    assert mock_tqdm.call_args.kwargs["total"] == compressed_size
+    assert pbar.n == compressed_size
 
 
 @patch("scribe_data.wikidata.parse_dump.LexemeProcessor")


### PR DESCRIPTION
<!---
Thank you for your pull request! 🚀
-->

### Contributor checklist

<!-- Please replace the empty checkboxes [] below with checked ones [x] accordingly. -->

- [X] This pull request is on a [separate branch](https://docs.github.com/en/get-started/quickstart/github-flow) and not the main branch
- [X] I have tested my code with the `pytest` command as directed in the [testing section of the contributing guide](https://github.com/scribe-org/Scribe-Data/blob/main/CONTRIBUTING.md#testing)

---

### Description

- -wdp re-scanned the lexeme dump once per lang×type.
- Parse all languages/types in one pass instead. Drive progress from compressed bytes so bars always hit 100%.
- use same tqdm logic for wikidata and wiktionary

<img width="1144" height="511" alt="image" src="https://github.com/user-attachments/assets/d57946c1-e417-4eee-a569-8cd739718980" />


<!--
Describe briefly what your pull request proposes to change. Especially if you have more than one commit, it is helpful to give a summary of what your contribution is trying to solve.

Also consider including the following:
- A description of the main files changed and what has been done in them (helps maintainers focus their review)
- A description of how you tested that your change actually works
- Pictures or a video of your change (if possible)
-->
 
