### PR TITLE
[Feat] Updates in Architecture.md 

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # [Architecture](https://github.com/scribe-org/Scribe-Data/blob/main/ARCHITECTURE.md)
 
-This markdown file documents the architecture for the Scribe-Data CLI - including all processes and the external systems and sources with which it interacts. The diagram details the CLI [convert](./src/scribe_data/cli/convert/), [download](./src/scribe_data/cli/download/), [get](./src/scribe_data/cli/get.py), [list](./src/scribe_data/cli/list/), [total](./src/scribe_data/cli/total/), [export_contracts, check_contracts and filter_data](./src/scribe_data/cli/contracts/) commands, with [interactive](./src/scribe_data/cli/interactive/) being a command itself and also an option within other commands via the `--interactive` (`-i`) option.
+This markdown file documents the architecture for the Scribe-Data CLI - including all processes and the external systems and sources with which it interacts. The diagram details the CLI [convert](./src/scribe_data/cli/convert/), [download](./src/scribe_data/cli/download/), [get](./src/scribe_data/cli/get.py), [list](./src/scribe_data/cli/list/), [total](./src/scribe_data/cli/total/) and [contact](./src/scribe_data/cli/contracts/) commands, with [interactive](./src/scribe_data/cli/interactive/) being a command itself and also an option within other commands via the `--interactive` (`-i`) option.
 
 CLI outputs that are used in multiple flows appear as nodes outside of any nodes for clarity. As the file is meant to be a living document, edits are welcome to expand and update it!
 
@@ -17,6 +17,7 @@ graph LR
     LEXEME_QUERIES[Internal generated\nlexeme queries]
     PROFANITY_QUERY[Internal template\nprofanity query]
     TOTAL_QUERY[Internal template\ntotal query]
+    CONTRACTS(Internal data contracts)
 
     %% Data sources
 
@@ -28,6 +29,7 @@ graph LR
     %% Outputs
 
     JSON(JSON files)
+    FILTJSON(Filtered JSON files)
     CTSV(CSV / TSV files)
     SQLITE(SQLITE DB)
     TERM(Terminal output)
@@ -44,14 +46,7 @@ graph LR
     CONV{{convert command}}
     INT{{interactive mode}}
     EXPORTC{{export_contracts command}}
-    CHECKC{{check_contracts command}}
     FILTERC{{filter_data command}}
-
-    %% Data contracts
-
-    CONTRACTS[(Data contract files)]
-    CDIR(Local contracts directory)
-    FILTJSON(Filtered JSON files)
 
     %% General flow
 
@@ -78,13 +73,9 @@ graph LR
     LIST ---> |Print output| TERM
     TOT ---> |Print output| TERM
 
-    CONTRACTS ---> |Copy bundled files| EXPORTC
-    EXPORTC ---> |Save locally| CDIR
-    CDIR ---> |Read contract rules| CHECKC
-    JSON ---> |Verify completeness| CHECKC
-    CHECKC ---> |Print output| TERM
-    CDIR ---> |Read contract rules| FILTERC
-    JSON ---> |Filter to contract scope| FILTERC
+    EXPORTC ---> |Save locally| CONTRACTS
+    CONTRACTS ---> |Read contract rules| FILTERC
+    JSON ---> |Filter to contract fields| FILTERC
     FILTERC ---> |Save locally| FILTJSON
 
     %% Subgraphs
@@ -114,11 +105,9 @@ graph LR
     end
 
     subgraph CONTRACTS_FLOW [data contracts flow]
-    CONTRACTS
     EXPORTC
-    CHECKC
     FILTERC
-    CDIR
+    CONTRACTS
     end
 ```
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # [Architecture](https://github.com/scribe-org/Scribe-Data/blob/main/ARCHITECTURE.md)
 
-This markdown file documents the architecture for the Scribe-Data CLI - including all processes and the external systems and sources with which it interacts. The diagram details the CLI [convert](./src/scribe_data/cli/convert/), [download](./src/scribe_data/cli/download/), [get](./src/scribe_data/cli/get.py), [list](./src/scribe_data/cli/list/) and [total](./src/scribe_data/cli/total/) commands, with [interactive](./src/scribe_data/cli/interactive/) being a command itself and also an option within other commands via the `--interactive` (`-i`) option.
+This markdown file documents the architecture for the Scribe-Data CLI - including all processes and the external systems and sources with which it interacts. The diagram details the CLI [convert](./src/scribe_data/cli/convert/), [download](./src/scribe_data/cli/download/), [get](./src/scribe_data/cli/get.py), [list](./src/scribe_data/cli/list/), [total](./src/scribe_data/cli/total/), [export_contracts, check_contracts and filter_data](./src/scribe_data/cli/contracts/) commands, with [interactive](./src/scribe_data/cli/interactive/) being a command itself and also an option within other commands via the `--interactive` (`-i`) option.
 
 CLI outputs that are used in multiple flows appear as nodes outside of any nodes for clarity. As the file is meant to be a living document, edits are welcome to expand and update it!
 
@@ -43,6 +43,15 @@ graph LR
     TOT{{total command}}
     CONV{{convert command}}
     INT{{interactive mode}}
+    EXPORTC{{export_contracts command}}
+    CHECKC{{check_contracts command}}
+    FILTERC{{filter_data command}}
+
+    %% Data contracts
+
+    CONTRACTS[(Data contract files)]
+    CDIR(Local contracts directory)
+    FILTJSON(Filtered JSON files)
 
     %% General flow
 
@@ -69,6 +78,15 @@ graph LR
     LIST ---> |Print output| TERM
     TOT ---> |Print output| TERM
 
+    CONTRACTS ---> |Copy bundled files| EXPORTC
+    EXPORTC ---> |Save locally| CDIR
+    CDIR ---> |Read contract rules| CHECKC
+    JSON ---> |Verify completeness| CHECKC
+    CHECKC ---> |Print output| TERM
+    CDIR ---> |Read contract rules| FILTERC
+    JSON ---> |Filter to contract scope| FILTERC
+    FILTERC ---> |Save locally| FILTJSON
+
     %% Subgraphs
 
     subgraph DOWNLOAD_FLOW [download flow]
@@ -93,6 +111,14 @@ graph LR
 
     subgraph LIST_FLOW [list flow]
     DATA ---> |Read CLI\ninternal data| LIST
+    end
+
+    subgraph CONTRACTS_FLOW [data contracts flow]
+    CONTRACTS
+    EXPORTC
+    CHECKC
+    FILTERC
+    CDIR
     end
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
 
 - The handling of missing language directories in the SQLite conversion process has been dramatically improved to communicate to the user which languages are missing and also alert them that no SQLite databases will be created if no data is available for any of the desired languages.
 
+### 📝 Documentation
+
+- The [architecture diagram](./ARCHITECTURE.md) was updated to include the data contracts flow (`export_contracts`, `check_contracts` and `filter_data`).
+
 ### ✅ Tests
 
 - Testing for various parts of the CLI was expanded ([#623](https://github.com/scribe-org/Scribe-Data/issues/623)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,14 +23,14 @@ Emojis for the following are chosen based on [gitmoji](https://gitmoji.dev/).
 
 - The handling of missing language directories in the SQLite conversion process has been dramatically improved to communicate to the user which languages are missing and also alert them that no SQLite databases will be created if no data is available for any of the desired languages.
 
-### 📝 Documentation
-
-- The [architecture diagram](./ARCHITECTURE.md) was updated to include the data contracts flow (`export_contracts`, `check_contracts` and `filter_data`).
-
 ### ✅ Tests
 
 - Testing for various parts of the CLI was expanded ([#623](https://github.com/scribe-org/Scribe-Data/issues/623)).
 - Local pre-commit hooks are now ran with [prek](https://prek.j178.dev/) instead of `pre-commit`.
+
+### 📝 Documentation
+
+- An [architecture diagram](./ARCHITECTURE.md) was created to detail the various functionalities of the CLI ([#712](https://github.com/scribe-org/Scribe-Data/issues/712)).
 
 ### ♻️ Code Refactoring
 


### PR DESCRIPTION
**Closes** [#713](https://github.com/scribe-org/Scribe-Data/issues/713)

Adds the missing Data Contracts flow to the **ARCHITECTURE.md** Mermaid diagram. Previously, **export_contracts,** **check_contracts**, and **filter_data** were real, documented commands with no representation in the architecture diagram.

Added a new **CONTRACTS_FLOW** subgraph showing:
A per-language contract file as the source node
**export_contracts** pulling the contract out
**check_contracts** verifying a GET export against the contract
**filter_data** trimming a GET export down to only what the contract calls for
Connected the new subgraph to the existing JSON files output node, since contracts operate on get exports
Kept node/edge naming and label conventions consistent with the rest of the diagram